### PR TITLE
Improve Dask Gateway page, fix Slurm typos

### DIFF
--- a/content/docs/batch-computing/how-to-submit-a-job-to-slurm.md
+++ b/content/docs/batch-computing/how-to-submit-a-job-to-slurm.md
@@ -169,14 +169,14 @@ submission would look something like this:
 #SBATCH --time=30:00
 #SBATCH --array=1-10
 module add jasr
-Rscript TestRFile.R datset${Slurm_ARRAY_TASK_ID}.csv
+Rscript TestRFile.R datset${SLURM_ARRAY_TASK_ID}.csv
 ```
 
 Here the important differences are :
 
 - The array is created by Slurm directive `--array=1-10` by including elements numbered `[1-10]`to represent our 10 variations
 - The error and output file have the array  index `%a` included  in the name and `%A` is the job ID.
-- The environment variable `$Slurm_ARRAY_TASK_ID` in the `Rscript` command is expanded to give the job index
+- The environment variable `$SLURM_ARRAY_TASK_ID` in the `Rscript` command is expanded to give the job index
 
 When the job is submitted, Slurm will create 10 tasks under the single job
 ID. The job array script is submitted in the usual way:

--- a/content/docs/batch-computing/lotus-overview.md
+++ b/content/docs/batch-computing/lotus-overview.md
@@ -68,11 +68,11 @@ practice outlined in this documentation]({{< ref "tips-for-new-users" >}}).
 
 ## How to gain access to LOTUS
 
-LOTUS is accessible via the batch scheduler system SLURM that is running
+LOTUS is accessible via the batch scheduler system Slurm that is running
 across all JASMIN scientific analysis servers `sci[1-8].jasmin.ac.uk`.
 
 From the above servers, it is possible to submit, monitor, and control batch
-jobs using the SLURM commands.
+jobs using the Slurm commands.
 
 Please note that if you have only recently requested access to [JASMIN login
 services]({{< ref "get-login-account" >}}) and had this approved, there can

--- a/content/docs/data-transfer/scheduling-automating-transfers.md
+++ b/content/docs/data-transfer/scheduling-automating-transfers.md
@@ -59,7 +59,7 @@ We need it to:
 - have that script initiate downloads using LOTUS nodes
 
 In the examples below, we use the `test` queue (or partition, as queues are
-known in SLURM). You can use this for testing, but once you know roughly how
+known in Slurm). You can use this for testing, but once you know roughly how
 long your download(s) should take, you should [choose an appropriate
 queue]({{< ref "slurm-queues" >}}) so that the jobs can be scheduled in a fair
 way alongside other users' jobs.

--- a/content/docs/interactive-computing/centos7-sci-login-xfer-servers.md
+++ b/content/docs/interactive-computing/centos7-sci-login-xfer-servers.md
@@ -51,7 +51,7 @@ workflows/tasks that:
 1. Use the [new software environments](https://drive.google.com/file/d/1gD9C0TZyNITibgDhlv3pRzgd4JjzVfBW/view)
 2. Do not make use of the software `/apps/contrib` (which has only been tested for RHEL6 operating systems)
 3. Do not make use of the software available under the `module` environment (which has only been tested for RHEL6 operating systems) except the modules `jaspy` and `jasmin-sci`
-4. A job submitted to the new batch scheduler SLURM will run on a CentOS7 node in the LOTUS cluster.
+4. A job submitted to the new batch scheduler Slurm will run on a CentOS7 node in the LOTUS cluster.
 
 **Table 2:** List of CentOS7 Scientific analysis servers
 

--- a/content/docs/interactive-computing/dask-gateway.md
+++ b/content/docs/interactive-computing/dask-gateway.md
@@ -8,23 +8,23 @@ tags:
 
 ## Introduction
 
-[Dask Gateway](https://gateway.dask.org/) is a service which manages [dask](https://dask.org) clusters for users.
-On JASMIN, it creates a dask cluster in {{<link "../batch-computing/lotus-overview.md">}}LOTUS{{</link>}}, our batch computing cluster. It automatically creates a dask for you, scheduling Slurm jobs to create dask schedulers and workers as appropriate.
+[Dask Gateway](https://gateway.dask.org/) is a service which manages [Dask](https://dask.org) clusters for users.
+On JASMIN, it creates a Dask cluster in {{<link "../batch-computing/lotus-overview.md">}}LOTUS{{</link>}}, our batch computing cluster. It automatically creates a Dask for you, scheduling Slurm jobs to create Dask schedulers and workers as appropriate.
 
 ## Prerequisites
 
-Before using Dask Gateway on JASMIN, you will need: 
+Before using Dask Gateway on JASMIN, you will need:
 
 1. An existing JASMIN account and valid `jasmin-login` access role: {{<button size="sm" href="https://accounts.jasmin.ac.uk/services/login_services/jasmin-login/">}}Apply here{{</button>}}
 2. **Subsequently** (once `jasmin-login` has been approved and completed), the `dask` access role: {{<button size="sm" href="https://accounts.jasmin.ac.uk/services/additional_services/dask/">}}Apply here{{</button>}}
 
 The `jasmin-login` access role ensures that your account is set up with access to the LOTUS batch processing cluster, while the `dask` role grants access to the special LOTUS partition used by the Dask Gateway service.
 
-## Creating a dask cluster
+## Creating a Dask cluster
 
 ### In the JASMIN Notebooks service
 
-In the {{<link "jasmin-notebooks-service">}}JASMIN notebooks service{{</link>}}, authentication to dask-gateway happends automatically. You can use the snippet below to create a cluster and get a dask client which you can use:
+In the {{<link "jasmin-notebooks-service">}}JASMIN notebooks service{{</link>}}, authentication to `dask-gateway` happens automatically. You can use the snippet below to create a cluster and get a Dask client which you can use:
 
 ```python
 import dask_gateway
@@ -37,8 +37,8 @@ options = gw.cluster_options()
 options.worker_cores = 2
 
 # Create a dask cluster, or, if one already exists, connect to it.
-# This stage creates the scheduler job in SLURM, so may take some time.
-# While your job queues.
+# This stage creates the scheduler job in SLURM, so it may take some
+# time while your job queues.
 clusters = gw.list_clusters()
 if not clusters:
     cluster = gw.new_cluster(options, shutdown_on_close=False)
@@ -55,72 +55,79 @@ client = cluster.get_client()
 ### DO DASK WORK HERE ###
 #########################
 
-# When you are done and whish to release your cluster:
+# When you are done and wish to release your cluster:
 cluster.shutdown()
 ```
 
 ### Elsewhere on JASMIN
-(eg. on the `sci` machines)
+
+The following explains how to use the Dask Gateway elsewhere on JASMIN, for example, on the `sci` machines.
 
 {{<alert type="info">}}
-It is not necessary to do this if you only want to use dask in the JASMIN notebook service.
+It is not necessary to do this if you only want to use Dask in the JASMIN notebook service.
 {{</alert>}}
 
 At the current time, it is still necessary to use the notebooks service to generate an API token to allow you to connect to the gateway server.
 
 {{<alert type="danger">}}
-It is very important that your API token is not shared between users and remains secret. With it, another user can submit dask jobs to lotus as you, and they could exploit this to see anything in your jasmin account.
+It is very important that your API token is not shared between users and remains secret. With it, another user could submit Dask jobs to LOTUS as you, and they could exploit this to see anything in your JASMIN account.
 {{</alert>}}
 
 #### Setup
 
-1. Make a dask configuration folder in your home directory
+1. Make a Dask configuration folder in your home directory
 
-{{<command user="user" host="sci1">}}
-mkdir -p ~/.config/dask
-{{</command>}}
+    {{<command user="user" host="sci1">}}
+    mkdir -p ~/.config/dask
+    {{</command>}}
 
-2. Create a configuration file for dask-gateway
+2. Create a configuration file for `dask-gateway`
 
-{{<command user="user" host="sci1">}}
-touch ~/.config/dask/gateway.yaml
-{{</command>}}
+    {{<command user="user" host="sci1">}}
+    touch ~/.config/dask/gateway.yaml
+    {{</command>}}
 
 3. Change the permissions on the file so that only you can read it
 
-{{<command user="user" host="sci1">}}
-chmod 600 ~/.config/dask/gateway.yaml
-{{</command>}}
+    {{<command user="user" host="sci1">}}
+    chmod 600 ~/.config/dask/gateway.yaml
+    {{</command>}}
 
-4. Head to https://notebooks.jasmin.ac.uk/hub/token , put a note in the box to remind yourself what this token is for, press the **big orange button** then {{<mark>}}copy{{</mark>}} then {{<mark>}}token{{</mark>}}.
+4. Head to the [API token generator page](https://notebooks.jasmin.ac.uk/hub/token), put a note in the box to remind yourself what this token is for, press the **big orange button**, then {{<mark>}}copy{{</mark>}} the {{<mark>}}token{{</mark>}}.
 
-5. Paste the following snippet into `~/.config/dask/gateway.yaml`, replace the part in brackets with the API token you just copied.
+5. Paste the following snippet into `~/.config/dask/gateway.yaml`, replace the entry on the final line with the API token you just created.
 
-```yaml
-gateway:
-  address: https://dask-gateway.jasmin.ac.uk
-  auth:
-    type: jupyterhub
-    kwargs:
-      api_token: replaceWithYourSecretAPIToken
+    ```yaml
+    gateway:
+      address: https://dask-gateway.jasmin.ac.uk
+      auth:
+        type: jupyterhub
+        kwargs:
+          api_token: replaceWithYourSecretAPIToken
+    ```
+
+6. You're done. You can now use `dask-gateway` from the command line.
+
+## Access the Dask dashboard
+
+To get the link to your Dask dashboard, run the following:
+
+```python
+print(client.dashboard_link)
 ```
 
-6. You're done. You can now use dask gateway from the command line.
+Currently the Dask dashboard is not accessible from a browser outside the JASMIN firewall. If your browser fails to load the dashboard link returned, please use our {{<link "graphical-linux-desktop-access-using-nx">}}graphical desktop service{{</link>}} to run a Firefox browser inside the firewall to view your dashboard.
 
-## Access the dask dashboard
+## Use a custom Python environment
 
-Currently the dask dashboard is not accessible from a browser outside the JASMIN firewall. If your browser fails to load the dashboard link returned, please use our {{<link "graphical-linux-desktop-access-using-nx">}}graphical desktop service{{</link>}} to run a Firefox browser inside the firewall to view your dashboard.
-
-## Use a custom python environment
-
-By default the jasmin notebooks service and dask gateway use the latest version of the `jaspy` software environment. However, often users would like to use their own software environments.
+By default the JASMIN Notebooks service and Dask Gateway use the latest version of the `jaspy` software environment. However, often users would like to use their own software environments.
 
 ### Understanding the problem
 
-When dask gateway greates a dask cluster for a user, it runs a setup command to activate a conda environment or python `venv`.
-To have dask use your packages, you need to create a custom environment which you can pass to dask gateway to activate.
+When Dask Gateway creates a dask cluster for a user, it runs a setup command to activate a conda environment or python `venv`.
+To have Dask use your packages, you need to create a custom environment which you can pass to `dask-gateway` to activate.
 
-However, for techical reasons, it is not currently possible to use the same virtual environment in both the notebook service and on jasmin. So you will need to make two environments, one for your notebook to use and one for dask to use.
+However, for technical reasons, it is not currently possible to use the same virtual environment in both the notebook service and on JASMIN. So you will need to make two environments, one for your notebook to use and one for Dask to use.
 
 {{<alert type="info">}}
 It is VERY important that these environments have the same packages installed in them, and that the packages are exactly the same version in both environments.
@@ -128,12 +135,12 @@ It is VERY important that these environments have the same packages installed in
 If you do not keep packages and versions in-sync you can expect many confusing errors.
 {{</alert>}}
 
-If you use a self-containted conda enironment this is not a problem, and you can use this as a kernel in the notebooks service and on the `sci` machines. You can skip to {{<link "#putting-it-all-together">}}Putting it all together{{</link>}} below.
+If you use a self-contained conda environment this is not a problem, and you can use this as a kernel in the notebooks service and on the `sci` machines. You can skip to {{<link "#putting-it-all-together">}}Putting it all together{{</link>}} below.
 
-### Creating a virtual environment for dask.
+### Creating a virtual environment for Dask
 
-- Login to the JASMIN sci machines.
-- Activate jaspy
+- Login to the JASMIN `sci` machines.
+- Activate `jaspy`
 
 {{<command>}}
 module load jaspy
@@ -160,7 +167,7 @@ pip install dask-gateway dask lz4
 ### Creating a virtual environment for the notebooks service
 
 - Follow the instructions {{<link "creating-a-virtual-environment-in-the-notebooks-service">}}here{{</link>}} to create a virtual environment.
-- Install dask and dask gateway and dependencies: without this step your environment will not work with dask.
+- Install Dask and Dask Gateway and dependencies: without this step your environment will not work with Dask.
 
 {{<command>}}
 pip install dask-gateway dask lz4
@@ -169,14 +176,14 @@ pip install dask-gateway dask lz4
 ### Putting it all together
 
 - Set your notebook virtual environment as the kernel for the notebook in question as shown in the instructions linked above.
-- Set `options.worker_setup` to a command which will activate your dask virtual environment. For example
+- Set `options.worker_setup` to a command which will activate your Dask virtual environment. For example
 
 ```bash
 options.worker_setup = "source /home/users/example/name-of-environment/bin/activate"
 ```
 
-- If you have an existing dask cluster, close it and ensure all lotus jobs are stopped before recreating it using the new environment.
+- If you have an existing Dask cluster, close it and ensure all LOTUS jobs are stopped before recreating it using the new environment.
 
 ## Code Examples
 
-Examples of code and notebooks which can be used to test the JASMIN dask gateway service are [available on GitHub](https://github.com/cedadev/jasmin-daskgateway/tree/main/examples).
+Examples of code and notebooks which can be used to test the JASMIN Dask Gateway service are [available on GitHub](https://github.com/cedadev/jasmin-daskgateway/tree/main/examples).

--- a/content/docs/interactive-computing/dask-gateway.md
+++ b/content/docs/interactive-computing/dask-gateway.md
@@ -36,8 +36,8 @@ gw = dask_gateway.Gateway("https://dask-gateway.jasmin.ac.uk", auth="jupyterhub"
 options = gw.cluster_options()
 options.worker_cores = 2
 
-# Create a dask cluster, or, if one already exists, connect to it.
-# This stage creates the scheduler job in SLURM, so it may take some
+# Create a Dask cluster, or, if one already exists, connect to it.
+# This stage creates the scheduler job in Slurm, so it may take some
 # time while your job queues.
 clusters = gw.list_clusters()
 if not clusters:
@@ -48,7 +48,7 @@ else:
 # Create at least one worker, and allow your cluster to scale to three.
 cluster.adapt(minimum=1, maximum=3)
 
-# Get a dask client.
+# Get a Dask client.
 client = cluster.get_client()
 
 #########################

--- a/content/docs/mass/external-access-to-mass-faq.md
+++ b/content/docs/mass/external-access-to-mass-faq.md
@@ -277,7 +277,7 @@ scp userid@xfer1.jasmin.ac.uk:/group_workspaces/cems/<project>/jasmin_file.pp my
   
   {{< accordion-item header="Can I run MASS retrievals on LOTUS or through a workload manager?" >}}
 In addition to the interactive mass-cli server there is also the moose1 server
-that is only accessible through the {{<link "../batch-computing/lotus-overview">}}LOTUS batch processing cluster{{</link>}}. To submit jobs to moose1 you must use the [SLURM scheduler]({{< ref
+that is only accessible through the {{<link "../batch-computing/lotus-overview">}}LOTUS batch processing cluster{{</link>}}. To submit jobs to moose1 you must use the [Slurm scheduler]({{< ref
 "slurm-scheduler-overview" >}}). You will need to specify the account
 mass and partition mass, for example:
 
@@ -293,7 +293,7 @@ moo get $SRC_URI jasmin_copy.pp
 exit
 ```       
 
-It is also easy to configure the [Rose/Cylc workflow manager]({{< ref "rose-cylc-on-jasmin" >}}) to submit jobs to moose1 through the SLURM scheduler by
+It is also easy to configure the [Rose/Cylc workflow manager]({{< ref "rose-cylc-on-jasmin" >}}) to submit jobs to moose1 through the Slurm scheduler by
 including the following lines in your suite.rc file:
 
 ```


### PR DESCRIPTION
Dask (Dask Gateway page):
- Make capitalisation of Dask, JASMIN, and other terms consistent
- Fix some typos and improve wording
- Fix markdown-lint complaining

Slurm (across pages):
- Correct Slurm env variable name
- Capitalise Slurm as proper noun rather than SLURM