### PR TITLE
Update for LOTUS2 being generally available

### DIFF
--- a/content/docs/interactive-computing/sci-servers.md
+++ b/content/docs/interactive-computing/sci-servers.md
@@ -50,8 +50,8 @@ Physical servers are actually re-configured nodes within the LOTUS cluster and a
 configuration from the virtual `sci` servers, with limited outward connectivity.
 
 Outbound internet access (via NAT) is only
-for HTTP(S), so outbound SSH **will not work (to hosts outside of
-JASMIN) on these machines**. If you try to `git pull/clone` from external repositories e.g. Github, the operation will timeout with error `fatal: Could not read from remote repository`. The solution in this case is to access `git pull/clone` over **HTTPS** instead (check the repo for alternative access details).
+for HTTP(S), so **outbound SSH will not work (to hosts outside of
+JASMIN) on these machines**. This also applies to SSH-based transfer methods (scp, ftp, rsync) which anyway should be done instead on a [transfer server]({{%ref "transfer-servers"%}}). If you try to `git pull/clone` from external repositories e.g. Github using ssh, the operation will timeout with error `fatal: Could not read from remote repository`. The solution in this case is to access `git pull/clone` over **HTTPS** instead (check the repo for alternative access details).
 
 #### 3. /tmp on VMs
 
@@ -60,7 +60,7 @@ as this is used by the VM itself. It also provides no performance advantage as i
 
 #### 4. Arbiter
 
-A monitoring utility "**Arbiter**" is implemented across
+A monitoring utility **Arbiter** is used across
 all sci machines to control CPU and memory usage. This utility
 records the activity on the node, automatically sets limits on the resources
 available to each user. Users' processes are thus capped from

--- a/content/docs/interactive-computing/sci-servers.md
+++ b/content/docs/interactive-computing/sci-servers.md
@@ -21,11 +21,11 @@ The following sci servers are available:
 
 Server name  |  Virtual/Physical |  Processor model  |  CPU Cores  |  RAM (GB)  | /tmp max per user | /tmp size | slurm cluster
 ---|---|---|---|---|---|---|---
-`sci-vm-01` | virtual | Intel(R) Xeon(R) Gold 6348 CPU @ 2.60GHz | 8 | 32 GB | 512 MB | 80 GB virtual disk | old
-`sci-vm-02` | virtual | Intel(R) Xeon(R) Gold 6348 CPU @ 2.60GHz | 8 | 32 GB | 512 MB | 80 GB virtual disk | old
-`sci-vm-03` | virtual | Intel(R) Xeon(R) Gold 6348 CPU @ 2.60GHz | 8 | 32 GB | 512 MB | 80 GB virtual disk | old
-`sci-vm-04` | virtual | Intel(R) Xeon(R) Gold 6348 CPU @ 2.60GHz | 8 | 32 GB | 512 MB | 80 GB virtual disk | old
-`sci-vm-05` | virtual | Intel(R) Xeon(R) Gold 6348 CPU @ 2.60GHz | 8 | 32 GB | 512 MB | 80 GB virtual disk | old
+`sci-vm-01` | virtual | Intel(R) Xeon(R) Gold 6348 CPU @ 2.60GHz | 8 | 32 GB | 512 MB | 80 GB virtual disk | new
+`sci-vm-02` | virtual | Intel(R) Xeon(R) Gold 6348 CPU @ 2.60GHz | 8 | 32 GB | 512 MB | 80 GB virtual disk | new
+`sci-vm-03` | virtual | Intel(R) Xeon(R) Gold 6348 CPU @ 2.60GHz | 8 | 32 GB | 512 MB | 80 GB virtual disk | new
+`sci-vm-04` | virtual | Intel(R) Xeon(R) Gold 6348 CPU @ 2.60GHz | 8 | 32 GB | 512 MB | 80 GB virtual disk | new
+`sci-vm-05` | virtual | Intel(R) Xeon(R) Gold 6348 CPU @ 2.60GHz | 8 | 32 GB | 512 MB | 80 GB virtual disk | new
 `sci-ph-01` | physical | AMD EPYC 74F3 | 48 | 2 TB | 20 GB | 2 x 446 GB SATA SSD | new
 `sci-ph-02` | physical | AMD EPYC 74F3 | 48 | 2 TB | 20 GB | 2 x 446 GB SATA SSD | new
 `sci-ph-03` | physical | AMD EPYC 9654 | 48 | 1.5 TB | 20 GB | 480 GB SATA SSD + 800 GB NvMe SSD | new

--- a/content/docs/software-on-jasmin/rocky9-migration-2024.md
+++ b/content/docs/software-on-jasmin/rocky9-migration-2024.md
@@ -132,8 +132,7 @@ Notes:
   - for a more richly-featured editor or Integrated Development Environment (IDE), users should consider using
    the remote editing features of {{<link href="https://code.visualstudio.com/docs/remote/ssh">}}VSCode{{</link>}} or 
    {{<link "https://www.jetbrains.com/pycharm/">}}PyCharm{{</link>}}, since these can be installed and customised locally
-   by the user to their taste rather than needing central installation and management on JASMIN. Watch this space for
-   further advice about how to configure and use VSCode in this way.
+   by the user to their taste rather than needing central installation and management on JASMIN. See [access from VSCode]({{% ref "access-from-vscode"%}}).
 - See {{<link "#jaspy">}}jaspy{{</link>}}, {{<link "#jasr">}}jasr{{</link>}} and {{<link "#jasmin-sci">}}jasmin-sci{{</link>}}
 sections below for further information on software.
 - For graphical applications, use the {{<link "#nx-login-nodes">}}NoMachine NX service{{</link>}} rather than
@@ -161,7 +160,7 @@ Notes:
 - Same applies re. **SSH client version**, see [login nodes]({{% ref "#login-nodes" %}})
 - If using cron on `xfer-vm-03`, you must use [crontamer]({{% ref "using-cron/#crontamer" %}})
 - Throttle any automated transfers to avoid many SSH connections in quick succession, otherwise you may get blocked.
-- Consider using [Globus]({{% ref "#globus-data-transfer-service" %}}) for any data transfer in or out of JASMIN
+- Consider using [Globus]({{% ref "#globus-data-transfer-service" %}}) for best performance & reliability for transfers in or out of JASMIN
 - A new software collection `jasmin-xfer` has now been added to these servers, providing these tools:
 
 ```txt
@@ -196,7 +195,7 @@ Notes:
 
 ### GridFTP server
 
-Due to difficulties installing and configuring the suite of legacy components needed to support "old-style" gridftp, **we will not now be providing a replacement for the old server `gridftp1`**. Please familiarise yourself with using Globus, see below: this provides equivalent (and better) functionality.
+Due to difficulties installing and configuring the suite of legacy components needed to support "old-style" gridftp, this services has now been discontinued. Please familiarise yourself with using Globus, see below: this provides equivalent (and better) functionality.
 
 Note this does affect gridftp-over-ssh (`sshftp`) which is available on the new `hpxfer` nodes in the same way as their predecessors, see above.
 
@@ -263,7 +262,7 @@ Notes:
 - \*2 CPU reserved for system processes
 - Overall ~55,000 cores: ~triples capacity pf previous cluster
 - New nodes will form a new cluster, managed separately to the "old" LOTUS
-- Submission to the new cluster is now via all `sci` nodes
+- Submission to the new cluster is now via any `sci-vm-*` or `sci-ph-*` node
 
 ### New LOTUS2 cluster initial submission guide
 
@@ -284,15 +283,17 @@ Output should be similar to one or more of the lines below.
 {{<command user="user" host="sci-ph-01">}}
 useraccounts
 (out)# sacctmgr show user fred withassoc format=user,account,qos%-50
-(out)      User     Account QOS
-(out)---------- ----------- --------------------------------------------------
-(out)      fred    mybiggws debug,highres,long,short,standard
-(out)      fred  jules-test jules-test
-(out)      fred  no-project debug,highres,long,short,standard
-(out)      fred      orchid debug,highres,long,short,standard
+(out)User       Account        QOS
+(out)---------- -------------- --------------------------------------------------
+(out)      fred  mybiggws      debug,highres,long,short,standard
+(out)      fred  jules-test    jules-test
+(out)      fred  no-project    debug,highres,long,short,standard
+(out)      fred  shobu
+(out)      fred  orchid        debug,highres,long,short,standard
 {{</command>}}
 
 Users who do not belong to any group workspaces will be assigned the `no-project` account and should use that in their job submissions.
+Please ignore and do not use the group `shobu`.
 
 #### Partitions and QoS
 

--- a/content/docs/software-on-jasmin/rocky9-migration-2024.md
+++ b/content/docs/software-on-jasmin/rocky9-migration-2024.md
@@ -113,11 +113,11 @@ The new list is as follows:
 name | status | specs | slurm cluster
 --- | --- | --- | ---
 Virtual servers | | |
-`sci-vm-01.jasmin.ac.uk` | {{< icon fas circle-check text-success >}} Ready to use | 24 CPU / 64 GB RAM / 80 GB (virtual disk) | old
-`sci-vm-02.jasmin.ac.uk` | {{< icon fas circle-check text-success >}} Ready to use | 24 CPU / 64 GB RAM / 80 GB (virtual disk) | old
-`sci-vm-03.jasmin.ac.uk` | {{< icon fas circle-check text-success >}} Ready to use | 24 CPU / 64 GB RAM / 80 GB (virtual disk) | old
-`sci-vm-04.jasmin.ac.uk` | {{< icon fas circle-check text-success >}} Ready to use | 24 CPU / 64 GB RAM / 80 GB (virtual disk) | old
-`sci-vm-05.jasmin.ac.uk` | {{< icon fas circle-check text-success >}} Ready to use | 24 CPU / 64 GB RAM / 80 GB (virtual disk) | old
+`sci-vm-01.jasmin.ac.uk` | {{< icon fas circle-check text-success >}} Ready to use | 24 CPU / 64 GB RAM / 80 GB (virtual disk) | new
+`sci-vm-02.jasmin.ac.uk` | {{< icon fas circle-check text-success >}} Ready to use | 24 CPU / 64 GB RAM / 80 GB (virtual disk) | new
+`sci-vm-03.jasmin.ac.uk` | {{< icon fas circle-check text-success >}} Ready to use | 24 CPU / 64 GB RAM / 80 GB (virtual disk) | new
+`sci-vm-04.jasmin.ac.uk` | {{< icon fas circle-check text-success >}} Ready to use | 24 CPU / 64 GB RAM / 80 GB (virtual disk) | new
+`sci-vm-05.jasmin.ac.uk` | {{< icon fas circle-check text-success >}} Ready to use | 24 CPU / 64 GB RAM / 80 GB (virtual disk) | new
 Physical servers | | |
 `sci-ph-01.jasmin.ac.uk` | {{< icon fas circle-check text-success >}} Ready to use | 48 CPU AMD EPYC 74F3 / 2 TB RAM / 2 x 446 GB SATA SSD | new
 `sci-ph-02.jasmin.ac.uk` | {{< icon fas circle-check text-success >}} Ready to use | 48 CPU AMD EPYC 74F3 / 2 TB RAM / 2 x 446 GB SATA SSD | new
@@ -263,11 +263,7 @@ Notes:
 - \*2 CPU reserved for system processes
 - Overall ~55,000 cores: ~triples capacity pf previous cluster
 - New nodes will form a new cluster, managed separately to the "old" LOTUS
-- Submission to the new cluster is now via `sci-ph-0[1,2,3]`
-  - and from **one** additional physical node (details TBC) with extended CentOS7 support, with restricted access to enable use of Cylc 7 for limited period.
-- Submission to "old" LOTUS will **only** be from current CentOS7 `sci` machines `sci[1-8]` **until 18 Feb 2025**.
-  - and from **one** additional physical node (details TBC) with extended CentOS7 support, with restricted access to enable use of Cylc 7 for limited period.
-- Nodes will gradually be removed from the "old" cluster and retired, timetable TBC once new cluster is up & running.
+- Submission to the new cluster is now via all `sci` nodes
 
 ### New LOTUS2 cluster initial submission guide
 
@@ -277,32 +273,23 @@ Please see the details below on how to access LOTUS2 and how to submit a job to 
 **These require a Slurm account, partition and quality of service (QoS) to be specified at job submission time**.
 {{</alert>}}
 
-#### LOTUS2 batch job submission hosts
-
-Login to one of the following hosts:
-
-- `sci-ph-01.jasmin.ac.uk`
-- `sci-ph-02.jasmin.ac.uk`
-- `sci-ph-03.jasmin.ac.uk`
-
-The hostname will be displayed as `hostNNN`. This host can be reached in the normal way via a login server.
-
-(Other submission hosts will be added in due course, see above)
-
 #### New Slurm job accounting hierarchy
 
 Slurm accounting by project has been introduced as a means of monitoring compute usage by projects on JASMIN. These projects align with group workspaces (GWSs),
 and you will automatically be added to Slurm accounts corresponding to any GWS projects that you belong to.
 
-To find what Slurm accounts and quality of services that you have access to, use the `useraccounts` command on the job submission host (currently `sci-ph-03.jasmin.ac.uk`).
+To find what Slurm accounts and quality of services that you have access to, use the `useraccounts` command on any `sci` machine.
 Output should be similar to one or more of the lines below.
 
-{{<command user="user" host="host1000">}}
+{{<command user="user" host="sci-ph-01">}}
 useraccounts
-(out)fred  mybiggws debug,highres,long,short,standard
-(out)fred  jules-test jules-test
-(out)fred  no-project debug,highres,long,short,standard
-(out)fred  orchid debug,highres,long,short,standard
+(out)# sacctmgr show user fred withassoc format=user,account,qos%-50
+(out)      User     Account QOS
+(out)---------- ----------- --------------------------------------------------
+(out)      fred    mybiggws debug,highres,long,short,standard
+(out)      fred  jules-test jules-test
+(out)      fred  no-project debug,highres,long,short,standard
+(out)      fred      orchid debug,highres,long,short,standard
 {{</command>}}
 
 Users who do not belong to any group workspaces will be assigned the `no-project` account and should use that in their job submissions.
@@ -352,7 +339,7 @@ where {{<link "https://slurm.schedmd.com/sbatch.html#OPT_time">}}`time`{{</link>
 Save this script file as e.g.`test_submit.sh`
 Then submit this with:
 
-{{<command user="user" host="host1000">}}
+{{<command user="user" host="sci-ph-01">}}
 sbatch test_submit.sh
 {{</command>}}
 
@@ -360,7 +347,7 @@ For a pseudo-interactive session on a LOTUS2 compute node:
 
 (again, replace `mygws` with an account that you belong to, from the `useraccounts` command)
 
-{{<command user="user" host="host1000">}}
+{{<command user="user" host="sci-ph-01">}}
 srun --account=mygws --partition=debug --qos=debug --pty /bin/bash
 (out)srun: job 586 queued and waiting for resources
 (out)srun: job 586 has been allocated resources


### PR DESCRIPTION
Updated Rocky 9 migration page with details about LOTUS2 being available on all sci machines. Also updated the list on the sci servers page.

Need to next update the how-to-submit-a-job-to-slurm page.