### PR TITLE
Fix footer helpdesk link to open contact us page / toggle beacon

### DIFF
--- a/layouts/partials/footer/footer.html
+++ b/layouts/partials/footer/footer.html
@@ -51,7 +51,8 @@
                 </h2>
                 <ul class="list-unstyled">
                     <li>
-                        <a href="javascript:void(0);" id="beacon" onclick="Beacon('toggle')">Helpdesk</a>
+                        {{/*  Sets up the Helpdesk link to either toggle the Beacon or go to the JASMIN contact us page if it's not ready  */}}
+                        <a href="javascript:void(0);" id="beacon" onclick="if (Beacon('info') === undefined) { window.location = '{{ site.Params.links.jasmin }}/help/contact/' } else { Beacon('toggle') }">Helpdesk</a>
                     </li>
                 </ul>
             </div>


### PR DESCRIPTION
If the beacon isn't ready then as a fallback, the helpdesk link in the footer can now open the JASMIN contact us page.