### PR TITLE
update MASS client description

### DIFF
--- a/content/docs/data-transfer/data-transfer-tools.md
+++ b/content/docs/data-transfer/data-transfer-tools.md
@@ -26,7 +26,7 @@ Tool | Info
 wget, curl  |  Download tools for accessing resources over HTTP primarily. (see 3rd party documentation)
 {{<link "../short-term-project-storage/share-gws-data-via-http">}}sharing GWS data via http{{</link>}} | for exposing part(s) of a Group Workspace via HTTP to users without JASMIN accounts.
 Python transfer tools  |  Methods of managing/scripting data transfer tasks using Python. You can use libraries such as `requests` in a Python 3 virtual environment on the transfer servers.  
-{{<link "../mass/external-access-to-mass-faq">}}MASS client (Met Office){{</link>}}|  A specific command-line tool installed on the mass-cli1.ceda.ac.uk server on JASMIN. Enables extractions from the Met Office MASS Archive.
+{{<link "../mass/external-access-to-mass-faq">}}MASS client (Met Office){{</link>}}|  A specific command-line tool installed on the mass-cli.jasmin.ac.uk server on JASMIN. Enables extractions from the Met Office MASS Archive.
 OPeNDAP  |  A transfer protocol for extracting subsets of files from a remote server (over HTTP)
 {{<link "rclone">}}rclone{{</link>}} |  A 3rd party, open-source command-line utility which can interface to, and synchronise data between, a wide variety of cloud and other storage backends, such as Google Drive and AWS S3 compatible object stores. It can also sync data over SSH.   This utility is not installed on JASMIN but is well-documented and trivial for users to download and configure themselves on one of the {{<link "../interactive-computing/transfer-servers">}}data transfer servers{{</link>}} **Please note {{<link "rclone#installing-rclone-for-yourself-on-jasmin">}}install instructions{{</link>}}, and {{<link "rclone/#dos-and-donts">}}dos and don'ts{{</link>}}for rclone on JASMIN**.
 {.table .table-striped}

--- a/content/docs/data-transfer/data-transfer-tools.md
+++ b/content/docs/data-transfer/data-transfer-tools.md
@@ -26,7 +26,7 @@ Tool | Info
 wget, curl  |  Download tools for accessing resources over HTTP primarily. (see 3rd party documentation)
 {{<link "../short-term-project-storage/share-gws-data-via-http">}}sharing GWS data via http{{</link>}} | for exposing part(s) of a Group Workspace via HTTP to users without JASMIN accounts.
 Python transfer tools  |  Methods of managing/scripting data transfer tasks using Python. You can use libraries such as `requests` in a Python 3 virtual environment on the transfer servers.  
-{{<link "../mass/external-access-to-mass-faq">}}MASS client (Met Office){{</link>}}|  A specific command-line tool installed on the mass-cli.jasmin.ac.uk server on JASMIN. Enables extractions from the Met Office MASS Archive.
+{{<link "../mass/external-access-to-mass-faq">}}MASS client (Met Office){{</link>}}|  A specific command-line tool installed on the `mass-cli` server on JASMIN. Enables extractions from the Met Office MASS Archive.
 OPeNDAP  |  A transfer protocol for extracting subsets of files from a remote server (over HTTP)
 {{<link "rclone">}}rclone{{</link>}} |  A 3rd party, open-source command-line utility which can interface to, and synchronise data between, a wide variety of cloud and other storage backends, such as Google Drive and AWS S3 compatible object stores. It can also sync data over SSH.   This utility is not installed on JASMIN but is well-documented and trivial for users to download and configure themselves on one of the {{<link "../interactive-computing/transfer-servers">}}data transfer servers{{</link>}} **Please note {{<link "rclone#installing-rclone-for-yourself-on-jasmin">}}install instructions{{</link>}}, and {{<link "rclone/#dos-and-donts">}}dos and don'ts{{</link>}}for rclone on JASMIN**.
 {.table .table-striped}

--- a/content/docs/mass/external-access-to-mass-faq.md
+++ b/content/docs/mass/external-access-to-mass-faq.md
@@ -276,13 +276,12 @@ scp userid@xfer-vm-01.jasmin.ac.uk:/group_workspaces/cems/<project>/jasmin_file.
   {{< /accordion-item >}}
   
   {{< accordion-item header="Can I run MASS retrievals on LOTUS or through a workload manager?" >}}
-In addition to the interactive mass-cli server there is also the moose1 server
-that is only accessible through the {{<link "../batch-computing/lotus-overview">}}LOTUS batch processing cluster{{</link>}}. To submit jobs to moose1 you must use the [Slurm scheduler]({{< ref
+In addition to the interactive mass-cli server there is also a node of the {{<link "../batch-computing/lotus-overview">}}LOTUS batch processing cluster{{</link>}} with the MASS client installed. To submit jobs to this, you must use the [Slurm scheduler]({{< ref
 "slurm-scheduler-overview" >}}). You will need to specify the account
-mass and partition mass, for example:
+mass, partition mass and QOS mass, for example:
 
 ```
- sbatch -A mass -p mass [<options>] <jobscript>
+ sbatch -A mass -p mass -q mass [<options>] <jobscript>
 ``` 
 
 where \<jobscript\> looks something like:
@@ -302,6 +301,7 @@ including the following lines in your suite.rc file:
 [[[directives]]]
     --partition=mass
     --account=mass
+    --qos=mass
 [<options>]
 ```
 

--- a/content/docs/mass/external-access-to-mass-faq.md
+++ b/content/docs/mass/external-access-to-mass-faq.md
@@ -276,9 +276,14 @@ scp userid@xfer-vm-01.jasmin.ac.uk:/group_workspaces/cems/<project>/jasmin_file.
   {{< /accordion-item >}}
   
   {{< accordion-item header="Can I run MASS retrievals on LOTUS or through a workload manager?" >}}
-In addition to the interactive mass-cli server there is also a node of the {{<link "../batch-computing/lotus-overview">}}LOTUS batch processing cluster{{</link>}} with the MASS client installed. To submit jobs to this, you must use the [Slurm scheduler]({{< ref
-"slurm-scheduler-overview" >}}). You will need to specify the account
-mass, partition mass and QOS mass, for example:
+In addition to the interactive `mass-cli` server there is also a node of the [LOTUS batch processing cluster]({{< ref "lotus-overview">}}) lotus-overview with the MASS client installed. To submit jobs to this, you must use the [Slurm scheduler]({{< ref
+"slurm-scheduler-overview" >}}). You will need to specify: 
+
+- the **account** `mass`
+- **partition** `mass` and
+- **QOS** `mass`
+
+for example:
 
 ```
  sbatch -A mass -p mass -q mass [<options>] <jobscript>

--- a/content/docs/mass/how-to-apply-for-mass-access.md
+++ b/content/docs/mass/how-to-apply-for-mass-access.md
@@ -11,9 +11,9 @@ title: How to apply for MASS access
 
 To access data held in the Met Office MASS archive, you will need:
 
-- a sponsor 
-- access to the mass-cli client machine
-- a MASS account 
+- a sponsor
+- access to the `mass-cli` client machine
+- a MASS account
 
 Your sponsor will need to be a **Senior Met Office Scientist** with whom you
 are working on a collaborative research project. If you are a Met Office
@@ -42,7 +42,7 @@ with any details they may not have:
 The information you provide to the Met Office will be treated in accordance
 with the {{<link "https://www.metoffice.gov.uk/about-us/legal/privacy">}}Met Office Privacy Policy{{</link>}}, and your use of the service will be subject to the {{<link "https://metoffice.github.io/JASMIN-MASS-access/Terms_and_Conditions.html">}}Terms and Conditions of Use{{</link>}} for the service.
 
-### Step Two - Access to mass-cli
+### Step Two - Access to `mass-cli`
 
 Next you need to apply for {{<link "https://accounts.jasmin.ac.uk/services/additional_services/mass/">}}the MASS service{{</link>}} in the JASMIN Accounts Portal:
 

--- a/content/docs/mass/how-to-apply-for-mass-access.md
+++ b/content/docs/mass/how-to-apply-for-mass-access.md
@@ -12,7 +12,7 @@ title: How to apply for MASS access
 To access data held in the Met Office MASS archive, you will need:
 
 - a sponsor 
-- access to the mass-cli1 client machine
+- access to the mass-cli client machine
 - a MASS account 
 
 Your sponsor will need to be a **Senior Met Office Scientist** with whom you
@@ -42,7 +42,7 @@ with any details they may not have:
 The information you provide to the Met Office will be treated in accordance
 with the {{<link "https://www.metoffice.gov.uk/about-us/legal/privacy">}}Met Office Privacy Policy{{</link>}}, and your use of the service will be subject to the {{<link "https://metoffice.github.io/JASMIN-MASS-access/Terms_and_Conditions.html">}}Terms and Conditions of Use{{</link>}} for the service.
 
-### Step Two - Access to mass-cli1
+### Step Two - Access to mass-cli
 
 Next you need to apply for {{<link "https://accounts.jasmin.ac.uk/services/additional_services/mass/">}}the MASS service{{</link>}} in the JASMIN Accounts Portal:
 


### PR DESCRIPTION
I have asked SCD to update the alias `mass-cli` to point to `mass-cli2`, so refer to this in the docs rather than specific machine name -- and in addition, mention QOS for the LOTUS jobs