### PR TITLE
NoMachine Client download link update

### DIFF
--- a/content/docs/interactive-computing/graphical-linux-desktop-access-using-nx.md
+++ b/content/docs/interactive-computing/graphical-linux-desktop-access-using-nx.md
@@ -52,17 +52,14 @@ name | notes
 ## Installing NoMachine Enterprise Client
 
 Download the
-{{<link "https://www.nomachine.com/download-enterprise#NoMachine-Enterprise-Client" >}}appropriate version of the NoMachine Enterprise Client{{</link>}}
-from NoMachine.
-That page contains links to several different products: 
-**The only one you need to install is NoMachine Enterprise Client.**
+{{<link "https://downloads.nomachine.com/enterprise/?product=enterprise-client" >}}appropriate version of the NoMachine Enterprise Client{{</link>}}
+from NoMachine. The first time you click this link, you might be redirected to the homepage of the NoMachine download site. If you click the link a second time, you should be taken straight to the NoMachine Enterprise Client download page.
 
-Versions are available for Windows, Mac and Linux. You may need privileges on
-your local machine in order to install the software so you may need to ask for
-help from your local IT helpdesk.
+There are several different NoMachine products: 
+**the only one you need to install is NoMachine Enterprise Client.**
 
-Note that **Nomachine Enterprise Client** is a different application to the
-"Nomachine Enterprise Desktop" or "Nomachine" available from the more publicised download
+Note that **NoMachine Enterprise Client** is a different application to the
+"NoMachine Enterprise Desktop" or "NoMachine" available from the more publicised download
 links on the NoMachine website or other applications in the NoMachine suite:
 the desktop edition contains additional components to enable remote access to
 your **own** (local) machine from a remote location: perhaps convenient
@@ -70,6 +67,10 @@ but not what we are trying to enable for you here.
 
 The **NoMachine Enterprise Client** is a cut-down client to which connects to a remote
 server: in your case, the server is at the JASMIN end, where the desktop session will exist.
+
+Versions are available for Windows, Mac and Linux. You may need privileges on
+your local machine in order to install the software so you may need to ask for
+help from your local IT helpdesk.
 
 Remember to check for updates for the enterprise client to ensure you always
 have the latest stable version. You can configure the application to check for

--- a/content/docs/interactive-computing/graphical-linux-desktop-access-using-nx.md
+++ b/content/docs/interactive-computing/graphical-linux-desktop-access-using-nx.md
@@ -342,7 +342,7 @@ traffic or by a wrong server address. Please verify your configuration and try a
 
 ### Client version
 
-Make sure you have installed and are using the correct and most recent version of the {{<link "https://www.nomachine.com/download-enterprise#NoMachine-Enterprise-Client" >}}NoMachine Enterprise Client{{</link>}} (not the NoMachine Enterprise Desktop or any other applications from NoMachine).
+Make sure you have installed and are using the correct and most recent version of the NoMachine Enterprise Client (not the NoMachine Enterprise Desktop or any other applications from NoMachine). [Check the instructions above]({{% ref "graphical-linux-desktop-access-using-nx#installing-nomachine-enterprise-client" %}}) to make sure you have downloaded the correct application.
 
 ### Key format
 

--- a/content/docs/software-on-jasmin/rocky9-migration-2024.md
+++ b/content/docs/software-on-jasmin/rocky9-migration-2024.md
@@ -102,8 +102,8 @@ the same as the old `nx4` in this respect.
 - Use only with the NoMachine Enterprise Client to get a graphical Linux desktop, from where you can
   - use the Firefox browser on the linux desktop to access web resources only accessible within JASMIN
   - make onward connections to a `sci` server for using graphics-intensive applications
-- Make sure you are using the most up-to-date version of 
-{{<link "https://downloads.nomachine.com/download-enterprise/#NoMachine-Enterprise-Client">}}NoMachine Enterprise Client{{</link>}}.
+- Make sure you are using the most up-to-date version of the
+[NoMachine Enterprise Client]({{% ref "graphical-linux-desktop-access-using-nx/#installing-nomachine-enterprise-client" %}}).
 
 ### `sci` servers
 


### PR DESCRIPTION
- Consolidated NoMachine download links in one place (`graphical-linux-desktop-access-using-nx#installing-nomachine-enterprise-client`), in case we need to update it in future
- Update NX client link and clarify redirect, also re-arranged the installation section for clarity