### PR TITLE
LOTUS documentation updates August 2025

### DIFF
--- a/content/docs/batch-computing/how-to-submit-a-job-to-slurm.md
+++ b/content/docs/batch-computing/how-to-submit-a-job-to-slurm.md
@@ -59,56 +59,14 @@ sleep 5s
 
 Submitting the above script (if you had access to the `mygws` account) creates a job named `My test job` with an estimated run time of
 `00:01:00` (1 minute), memory requirement of `1M` (1 Megabyte), run against the account
-`mygws` on the partition `debug` using Qos `debug`, and writing its STDOUT (standard output) to file 
+`mygws` on the partition `debug` using QoS `debug`, and writing its STDOUT (standard output) to file 
 `%j.out` and its STDERR to file `%j.err` (where `%j` represents the job ID that the scheduler assigns to the job).
 
 The task itself is the command `sleep 5s` which just pauses for 5 seconds before exiting. This is what you would replace 
 with your actual processing command(s), so you need to have an idea of how long it will take to run (**TIP**: run it manually first with `time <cmd>` to find out!)
 
-For details of other submission parameters, see 
+For details about how to pick the right partition, QoS, and account, please read about the [Slurm queues on LOTUS]({{% ref "slurm-queues" %}}). For further submission parameters, see the quick reference about
 [job specification]({{% ref "slurm-quick-reference#job-specification" %}}).
-
-### New Slurm job accounting hierarchy
-
-Slurm accounting by project has been introduced as a means of monitoring compute usage by projects on JASMIN. These projects align with group workspaces (GWSs), and you will automatically be added to Slurm accounts corresponding to any GWS projects that you belong to.
-
-To find what Slurm accounts and quality of services (QoS) that you have access to, use the `useraccounts` command on any `sci` machine.
-Output should be similar to one or more of the lines below.
-
-{{<command user="user" host="sci-ph-01">}}
-useraccounts
-(out)# sacctmgr show user fred withassoc format=user,account,qos%-50
-(out)User       Account        QOS
-(out)---------- -------------- -------------------------------------
-(out)      fred  mygws         debug,high,long,short,standard
-(out)      fred  orchid        debug,high,long,short,standard
-{{</command>}}
-
-You should use the relevant account for your project's task with the `--account` directive in your job script.
-
-Users who do not belong to any group workspaces will be assigned the `no-project` account and should use that in their job submissions.
-Please ignore and do not use the group `shobu`.
-
-### Partitions and QoS
-
-There are two partitions currently available on LOTUS, with associated allowed quality of service (QoS) as shown below:
-
-| Partition | Allowed QoS |
-| --- | --- |
-| `standard` | `standard`, `short`, `long`, `high`, `dask` |
-| `debug` | `debug` |
-{.table .table-striped .w-auto}
-
-| QoS | Priority | Max CPUs per job | Max wall time |
-| --- | --- | --- | --- |
-| `standard` | 500 | 1 | 24 hours |
-| `short` | 550 | 1 | 4 hours |
-| `long` | 350 | 1 | 5 days |
-| `high` | 450 | 96 | 2 days |
-| `debug` | 500 | 8 | 1 hour |
-{.table .table-striped .w-auto}
-
-Once you've chosen the partition and QoS you need, provide the partition in the `--partition` directive and the QoS in the `--qos` directive.
 
 ## Method 2: Submit via command-line options
 

--- a/content/docs/batch-computing/how-to-submit-a-job-to-slurm.md
+++ b/content/docs/batch-computing/how-to-submit-a-job-to-slurm.md
@@ -37,7 +37,8 @@ The job script is a Bash script of user's application and includes a list of
 Slurm directives, prefixed with `#SBATCH` as shown in this example:
 
 {{<alert type="danger">}}
-Remove any trailing whitespace
+- Remove any trailing whitespace
+- Choose values for `account`, `partition` and `qos` that are valid for you.
 {{</alert>}}
 
 ```bash
@@ -65,7 +66,8 @@ Submitting the above script (if you had access to the `mygws` account) creates a
 The task itself is the command `sleep 5s` which just pauses for 5 seconds before exiting. This is what you would replace 
 with your actual processing command(s), so you need to have an idea of how long it will take to run (**TIP**: run it manually first with `time <cmd>` to find out!)
 
-For details about how to pick the right partition, QoS, and account, please read about the [Slurm queues on LOTUS]({{% ref "slurm-queues" %}}). For further submission parameters, see the quick reference about
+- For details about how to pick the right partition, QoS, and account, please read about the [Slurm queues on LOTUS]({{% ref "slurm-queues" %}}).
+- For further submission parameters, see the quick reference about
 [job specification]({{% ref "slurm-quick-reference#job-specification" %}}).
 
 ## Method 2: Submit via command-line options

--- a/content/docs/batch-computing/how-to-submit-a-job-to-slurm.md
+++ b/content/docs/batch-computing/how-to-submit-a-job-to-slurm.md
@@ -95,8 +95,8 @@ There are two partitions currently available on LOTUS, with associated allowed q
 
 | Partition | Allowed QoS |
 | --- | --- |
-| `standard` | `standard`, `short`, `long`, `high` |
-| `debug` | `debug`, `reservation` |
+| `standard` | `standard`, `short`, `long`, `high`, `dask` |
+| `debug` | `debug` |
 {.table .table-striped .w-auto}
 
 | QoS | Priority | Max CPUs per job | Max wall time |
@@ -286,3 +286,19 @@ If you use  the `squeue -u <username>` command  to list your active jobs, you
 will see 10 tasks with the same Job ID. The tasks can be distinguished by  the
 `[index]` e.g. jobID_index. Note that individual tasks may be allocated to a
 range of different hosts on LOTUS.
+
+## Troubleshooting
+
+If you have only recently requested access to [JASMIN login
+services]({{% ref "get-login-account" %}}) and had this approved, there can
+sometimes be a delay (typically up to a day, but in rare cases can be longer)
+before the necessary configuration is created for you on LOTUS. You will not
+be able to submit jobs to LOTUS until this has been completed.
+Typically, you would see an error message such as this, after an
+unsuccessful attempt to submit a job:
+
+```bash
+sbatch: error: Batch job submission failed: Invalid account or account/partition combination specified
+```
+
+If this occurs, please try again in 24 hours before contacting the JASMIN helpdesk.

--- a/content/docs/batch-computing/how-to-submit-an-mpi-parallel-job.md
+++ b/content/docs/batch-computing/how-to-submit-an-mpi-parallel-job.md
@@ -5,11 +5,6 @@ slug: how-to-submit-an-mpi-parallel-job
 title: How to submit an MPI parallel job
 ---
 
-{{<alert type="danger">}}
-Not yet reviewed for compatibility with the new cluster, April 2025.
-Please adapt using [new submission instructions](how-to-submit-a-job-to-slurm). This alert will be removed once updated.
-{{</alert>}}
-
 ## What is an MPI parallel job?
 
 An MPI parallel job runs on more than one core and more than one host using
@@ -22,13 +17,13 @@ cores. A simple script, such as the one given below could be saved as `my_script
 #SBATCH --time=00:30:00
 #SBATCH --mem=100M
 #SBATCH --account=mygws
-#SBATCH --partition=par-multi
-#SBATCH --qos=debug
+#SBATCH --partition=standard
+#SBATCH --qos=high
 #SBATCH -n 36
 #SBATCH -o %j.log
 #SBATCH -e %j.err
 
-# Load a module for the gcc OpenMPI library  (needed for mpi_myname.exe)
+# Load a module for the gcc OpenMPI library (needed for mpi_myname.exe)
 module load eb/OpenMPI/gcc/4.0.0
 
 # Start the job running using OpenMPI's "mpirun" job launcher
@@ -36,15 +31,8 @@ mpirun ./mpi_myname.exe
 ```
 
 `-n` refers to the number of processors or cores you wish to run on. The rest
-of  the `#SBATCH` input  options, and many more besides, can be found in  the
-`sbatch` manual  page or in the related articles. You must only use the `par-multi`
-queue for parallel jobs using MPI.
-
-For those familiar with LOTUS running Platform MPI and Platform LSF, please
-note that the job is started using the OpenMPI native `mpirun` command not the
-`mpirun.lotus` wrapper script that was previously required. We have provided
-an `mpirun.lotus` script for backward compatibility but it just runs the native
-`mpirun`.
+of the `#SBATCH` input  options, and many more besides, can be found in the
+`sbatch` manual page or in the related articles.
 
 To submit the job, do not run the script, but rather use it as the standard
 input to `sbatch`, like so:
@@ -53,12 +41,17 @@ input to `sbatch`, like so:
 sbatch --exclusive my_script_name.sbatch
 {{</command>}}
 
-The `--exclusive` flag  is used to group the parallel jobs onto hosts which
+The `--exclusive` flag is used to group the parallel jobs onto hosts which
 are allocated only to run this job. This ensures the best MPI communication
 consistency and bandwidth/latency for the job and ensures no interference from
 other users' jobs that might otherwise be running on those hosts.
 
 ## MPI implementation and Slurm
+
+{{<alert type="danger">}}
+The following about compilers has not yet been reviewed for compatibility with the new cluster, April 2025.
+This alert will be removed once updated.
+{{</alert>}}
 
 The OpenMPI library is the only supported MPI library on the cluster. OpenMPI
 v3.1.1 and v4.0.0 are provided which are fully MPI3 compliant. MPI I/O

--- a/content/docs/batch-computing/lotus-cluster-specification.md
+++ b/content/docs/batch-computing/lotus-cluster-specification.md
@@ -8,16 +8,12 @@ tags:
 title: LOTUS cluster specification
 ---
 
-{{<alert type="danger">}}
-Not yet reviewed for compatibility with the new cluster, April 2025.
-Please adapt using [new submission instructions](how-to-submit-a-job-to-slurm). This alert will be removed once updated.
-{{</alert>}}
-
 ## Current cluster specification
 
-LOTUS is a cluster of over 300 nodes/hosts and 19000 CPU cores. A node/host is
+LOTUS is a cluster of over 260 nodes/hosts and 50,000 CPU cores. A node/host is
 an individual computer in the cluster with more than 1 processor. Each
-node/host belongs to a specific host group. The number of processors (CPUs or
+node/host belongs to a specific host group. Occasionally nodes/hosts are taken
+out of the cluster for special purposes. The number of processors (CPUs or
 cores) per host is listed in Table 1 with the corresponding processor model
 and the size of the physical memory RAM available per node/host.
 
@@ -27,49 +23,5 @@ and the size of the physical memory RAM available per node/host.
 
 Host group name |  Number of nodes/hosts  |  Processor model |  CPUs per host |  RAM 
 ---|---|---|---|---  
-broadwell256G  |  37  |  Intel Xeon E5-2640-v4 "Broadwell"  |  20  |  256 GB  
-skylake348G  |  151  |  Intel Xeon Gold-5118 "Skylake"  |  24  |  348 GB  
-epyctwo1024G  | 200  |  AMD  |  48  |  1024 GB | 
+?  |  265  |  AMD EPYC 9654  |  192?  |  1536 GB  
 {.table .table-striped}
-
-## Selection of specific processor model
-
-To select a node/host with a specific processor model and memory, add the
-following Slurm directive to your job script 
-
-```bash
-#SBATCH --constraint="<host-group-name>"
-```
-
-For example 
-
-```bash
-#SBATCH --constraint="skylake348G"
-```
-
-{{< alert type="info" >}}
-Further notes
-
-`intel` and `amd` node types are defined in the Slurm configuration as a feature:
-- For any Intel node type use `#SBATCH --constraint="intel"`
-- For a specific Intel CPU model use the host group name (see Table 1)
-  - e.g. `#SBATCH --constraint="skylake348G"`
-- For AMD use ` #SBATCH --constraint="amd"`
-- There are 10 nodes of node type `skylake348G` with SSD disk mounted on /tmp 
-- LOTUS nodes of node type `epyctwo1024` are not available yet on the `par-multi` queue
-{{< /alert >}}
-
-{{< alert type="danger" >}}
-If you choose to compile code for specific architectures, do not expect it to run elsewhere in the system.
-{{< /alert >}}
-
-## Retired host groups no longer in use
-
-(For reference only)
-
-Host group name |  Number of nodes/hosts |  Processor model |  CPUs per host |  RAM  
----|---|---|---|---  
-~~haswell256G~~ |  ~~7~~ retired |  ~~Intel Xeon E5-2650-v3 "Haswell"~~  |  ~~20~~  | ~~256 GB~~
-~~ivybridge2000G~~  |  ~~3~~  -retired |  ~~Intel Xeon E7-4860-v2 "Ivy Bridge"~~  |  ~~48~~  | ~~2048 GB~~
-{.table .table-striped}
-

--- a/content/docs/batch-computing/lotus-cluster-specification.md
+++ b/content/docs/batch-computing/lotus-cluster-specification.md
@@ -10,9 +10,10 @@ title: LOTUS cluster specification
 
 ## Current cluster specification
 
-LOTUS is a cluster of over 260 nodes/hosts and 50,000 CPU cores. A node/host is
+LOTUS is a cluster of over 260 nodes/hosts and over 53,000 CPU cores. A node/host is
 an individual computer in the cluster with more than 1 processor. Each
-node/host belongs to a specific host group. Occasionally nodes/hosts are taken
+node/host belongs to a specific host group. The exact number of cores available varies
+as occasionally nodes/hosts are taken
 out of the cluster for special purposes. The number of processors (CPUs or
 cores) per host is listed in Table 1 with the corresponding processor model
 and the size of the physical memory RAM available per node/host.

--- a/content/docs/batch-computing/lotus-cluster-specification.md
+++ b/content/docs/batch-computing/lotus-cluster-specification.md
@@ -23,5 +23,5 @@ and the size of the physical memory RAM available per node/host.
 
 Host group name |  Number of nodes/hosts  |  Processor model |  CPUs per host |  RAM 
 ---|---|---|---|---  
-?  |  265  |  AMD EPYC 9654  |  192?  |  1536 GB  
+`AMD_EPYC_9654_1.5TB`  |  265  |  AMD EPYC 9654  |  192  |  1536 GB  
 {.table .table-striped}

--- a/content/docs/batch-computing/lotus-overview.md
+++ b/content/docs/batch-computing/lotus-overview.md
@@ -47,7 +47,7 @@ duration of a project.
 See [Access to Storage]({{% ref path="/docs/getting-started/storage" %}}) for details about which file
 systems are appropriate to use and how to access them.
 
-LOTUS currently has around 55,000 cores, but is heavily used and implements a
+LOTUS currently has over 55,000 cores, but is heavily used and implements a
 fair-share scheduling system between users. It is not intended as a substitute
 for dedicated HPC facilities, rather as a complementary environment in which
 model outputs can be analyzed and compared with observational data. Users with
@@ -68,16 +68,5 @@ all JASMIN [scientific analysis servers]({{% ref "sci-servers" %}}).
 From the above servers, it is possible to submit, monitor, and control batch
 jobs using the Slurm commands.
 
-Please note that if you have only recently requested access to [JASMIN login
-services]({{% ref "get-login-account" %}}) and had this approved, there can
-sometimes be a delay (typically up to a day, but in rare cases can be longer)
-before the necessary configuration is created for you on LOTUS. You will not
-be able to submit jobs to LOTUS queues until this has been completed.
-Typically you would see an error message such as this, after an
-unsuccessful attempt to submit a job:
-
-```bash
-sbatch: error: Batch job submission failed: Invalid account or account/partition combination specified
-```
-
-If this occurs, please try again in 24 hours before contacting the JASMIN helpdesk.
+For more details about how to use LOTUS, please see our article about
+[how to submit a job to Slurm]({{% ref "how-to-submit-a-job-to-slurm" %}}).

--- a/content/docs/batch-computing/lotus-overview.md
+++ b/content/docs/batch-computing/lotus-overview.md
@@ -47,7 +47,7 @@ duration of a project.
 See [Access to Storage]({{% ref path="/docs/getting-started/storage" %}}) for details about which file
 systems are appropriate to use and how to access them.
 
-LOTUS currently has over 55,000 cores, but is heavily used and implements a
+LOTUS currently has over 53,000 cores*, but is heavily used and implements a
 fair-share scheduling system between users. It is not intended as a substitute
 for dedicated HPC facilities, rather as a complementary environment in which
 model outputs can be analyzed and compared with observational data. Users with
@@ -55,6 +55,8 @@ large-scale compute-heavy requirements (in particular those requiring large-scal
 parallel processing) should look to access other parts of the national
 HPC infrastructure such as [ARCHER2](http://www.archer2.ac.uk/) or
 [MONSooN](http://collab.metoffice.gov.uk/twiki/bin/view/Support/MONSooN).
+
+*The exact number of cores available varies for operational reasons.
 
 In order to maintain a safe and reliable working environment for all within
 LOTUS and more widely within JASMIN, users are expected to follow [the best

--- a/content/docs/batch-computing/orchid-gpu-cluster.md
+++ b/content/docs/batch-computing/orchid-gpu-cluster.md
@@ -7,11 +7,6 @@ title: Orchid GPU cluster
 type: docs
 ---
 
-{{<alert type="danger">}}
-Not yet reviewed for compatibility with the new cluster, April 2025.
-Please adapt using [new submission instructions](how-to-submit-a-job-to-slurm). This alert will be removed once updated.
-{{</alert>}}
-
 ## GPU cluster spec
 
 The JASMIN GPU cluster is composed of 16 GPU nodes:
@@ -21,6 +16,8 @@ The JASMIN GPU cluster is composed of 16 GPU nodes:
 
 {{< image src="img/docs/gpu-cluster-orchid/file-NZmhCFPJx9.png" caption="ORCHID GPU cluster" >}}
 
+Note: the actual number of nodes may vary slightly over time due to operational reasons. You can check which nodes are available by checking the `STATE` column in `sinfo --partition=orchid`.
+
 ## Request access to ORCHID
 
 Before using ORCHID on JASMIN, you will need: 
@@ -28,7 +25,7 @@ Before using ORCHID on JASMIN, you will need:
 1. An existing JASMIN account and valid `jasmin-login` access role: {{<button size="sm" href="https://accounts.jasmin.ac.uk/services/login_services/jasmin-login/">}}Apply here{{</button>}}
 2. **Subsequently** (once `jasmin-login` has been approved and completed), the `orchid` access role: {{<button size="sm" href="https://accounts.jasmin.ac.uk/services/additional_services/orchid/">}}Apply here{{</button>}}
 
-The `jasmin-login` access role ensures that your account is set up with access to the LOTUS batch processing cluster, while the `orchid` role grants access to the special LOTUS partition used by ORCHID.
+The `jasmin-login` access role ensures that your account is set up with access to the LOTUS batch processing cluster, while the `orchid` role grants access to the special LOTUS partition and QoS used by ORCHID.
 
 Holding the `orchid` role also gives access to the GPU interactive node.
 
@@ -47,7 +44,7 @@ srun --gres=gpu:1 --partition=orchid --account=orchid --qos=orchid --pty /bin/ba
 (out)srun: job 19505658 has been allocated resources
 {{</command>}}
 
-At this point, your shell prompt will change to the GPU node `gpuhost004`, but with access to one GPU as shown by the NVDIA utility. You will have the one GPU allocated at this shell, as requested:
+At this point, your shell prompt will change to the GPU node `gpuhost004`, but with access to one GPU as shown by the NVIDIA utility. You will have the one GPU allocated at this shell, as requested:
 
 {{<command user="user" host="gpuhost004">}}
 nvidia-smi
@@ -84,14 +81,18 @@ or by adding the following preamble in the job script file
 1. `gpuhost015` and `gpuhost016` are the two largest nodes with 64 CPUs and 8 GPUs each.
 
 2. IMPORTANT **CUDA Version: 12.8**  Please add the following to your path 
-```bash
-export PATH=/usr/local/cuda-12.8/bin${PATH:+:${PATH}}
-```
+    ```bash
+    export PATH=/usr/local/cuda-12.8/bin${PATH:+:${PATH}}
+    ```
 
-3. The Slurm batch partition `orchid` has a maximum runtime of 24 hours and
-the default runtime is 1 hour. The maximum number of CPU cores per user is
-limited to 8 cores. If the limit is exceeded then the job is expected to be in
-a pending state with the reason being {{<mark>}}`QOSGrpCpuLimit`{{</mark>}}
+3. The following are the limits for the `orchid` QoS. If, for example, the CPU limit
+is exceeded, then the job is expected to be in a pending state with the reason being
+{{<mark>}}`QOSGrpCpuLimit`{{</mark>}}.
+
+    | QoS      | Priority | Max CPUs per job | Max wall time | Max jobs per user |
+    |----------|----------|------------------|---------------|-------------------|
+    | `orchid` | 350      | 8                | 2 days        | 8                 |
+    {.table .table-striped .w-auto}
 
 ## GPU interactive node outside Slurm
 
@@ -114,6 +115,8 @@ ssh gpuhost001.jc.rl.ac.uk
 - CUDA version 12.8
 - CUDA DNN (Deep Neural Network Library) version cudnn9-cuda-12
 - cuda-toolkit - version 12.8
-- Singularity version 4.2.2-1 checked version - supports NVIDIA/GPU containers
-- podman version 5.2.2
+- Singularity-CE version 4.3.2-1 checked version - supports NVIDIA/GPU containers
+- podman version 5.4.0
 - SCL Python 3.6
+
+Please note that the cluster may have newer software available. For example, you can check the current CUDA version by using `nvidia-smi`, or the Singularity version with `singularity --version`.

--- a/content/docs/batch-computing/slurm-queues.md
+++ b/content/docs/batch-computing/slurm-queues.md
@@ -29,7 +29,7 @@ waiting for their opportunity to use resources. The queue is specified in the
 job script file using Slurm scheduler directive like this:
 
 ```bash
-#SBATCH -p <partition=queue_name>`
+#SBATCH -p <partition=queue_name>
 ```
 
 where `<queue_name>` is the name of the queue/partition (Table 1. column 1)
@@ -57,129 +57,134 @@ The Slurm command `sinfo` reports the state of queues and nodes
 managed by Slurm. It has a wide variety of filtering, sorting, and formatting
 options.
 
-{{<command shell="bash">}}
+{{<command shell="bash" user="user" host="sci-ph-01">}}
 sinfo   
-(out)PARTITION     AVAIL  TIMELIMIT  NODES  STATE NODELIST
-(out)test             up    4:00:00     48   idle host[146-193]
-(out)short-serial*    up 1-00:00:00     48   idle host[146-193]
-(out)long-serial      up 7-00:00:00     48   idle host[146-193]
-(out)par-single       up 2-00:00:00     48   idle host[146-193]
-(out)par-multi        up 2-00:00:00     48   idle host[146-193]
-(out)high-mem         up 2-00:00:00     48   idle host[146-193]
-(out)lotus_gpu        up 7-00:00:00     48   idle host[146-193]
-(out)copy             up 7-00:00:00     48   idle host[146-193]
-(out)cpom-comet       up 7-00:00:00     48   idle host[146-193]
+(out)PARTITION AVAIL  TIMELIMIT  NODES STATE NODELIST
+(out)...
+(out)standard*    up 1-00:00:00    262  idle host[1004-1276]
+(out)debug*       up    1:00:00      3  idle host[1001-1003]
 (out)...
 {{</command>}}
 
-{{< alert type="info" >}}
-Queues other than the standard queues `test` , `short-serial` ,
-`long-serial`, `par-single`, `par-multi` and `high-mem` should be ignored
+{{<alert type="info">}}
+Queues other than the standard queues, `standard` and `debug`, should be ignored
 as they implement different job scheduling and control policies.
-{{< /alert >}}
+{{</alert>}}
 
-## 'sinfo' Output field description:
+### `sinfo` output field description:
 
-By default, the Slurm command 'sinfo' displays the following information:
+By default, the Slurm command `sinfo` displays the following information:
 
-- **PARTITION** : Partition name followed by **\*** for the default queue/partition
+- **PARTITION** : Partition name followed by `*` for the default queue/partition
 - **AVAIL** : State/availability of a queue/partition. Partition state: up or down.
-- **TIMELIMIT** : The maximum run time limit per job in each queue/partition is shown in TIMELIMIT in days- hours:minutes  :seconds . e.g. 2-00:00:00 is two days maximum runtime limit 
+- **TIMELIMIT** : The maximum run time limit per job in each queue/partition is shown in `days-hours:minutes:seconds`, e.g. `2-00:00:00` is two days maximum runtime limit
 - **NODES** : Count of nodes with this particular configuration e.g. 48 nodes
-- **STATE** : State of the nodes. Possible states include: allocated, down, drained, and idle. For example, the state "idle" means that the node is not allocated to any jobs and is available for use.
+- **STATE** : State of the nodes. Possible states include: allocated, down, drained, and idle. For example, the state `idle` means that the node is not allocated to any jobs and is available for use.
 - **NODELIST** List of node names associated with this queue/partition
 
 The `sinfo` example below, reports more complete information about the
-partition/queue short-serial
+partition/queue `debug`
 
-{{<command>}}
-sinfo --long --partition=short-serial
-(out)Tue May 12 18:04:54 2020
-(out)PARTITION    AVAIL TIMELIMIT JOB_SIZE  ROOT  OVERSUBS  GROUPS NODES    STATE NODELIST
-(out)short-serial* up  1-00:00:00  1-infinite  no  NO    all     48  idle host[146-193]
+{{<command user="user" host="sci-ph-01">}}
+sinfo --long --partition=debug
+(out)PARTITION AVAIL TIMELIMIT   JOB_SIZE ROOT OVERSUBS GROUPS  NODES STATE RESERVATION NODELIST
+(out)debug        up   1:00:00 1-infinite   no       NO    all      3  idle             host[1001-1003]
 {{</command>}}
 
-## How to choose a Slurm queue/partition
+## Queues and QoS
 
-### Test queue
+Queues/partitions are further divided up into Quality of Services (QoS),
+which determine further restrictions about your job, for example, how long it can
+run or how many CPU cores it can use.
 
-The `test` queue can be used to test new workflows and also to help new
-users to familiarise themselves with the Slurm batch system. Both serial and
-parallel code can be tested on the `test`queue. The maximum runtime is 4 hrs
-and the maximum number of jobs per user is 8 job slots. The maximum number of
-cores for a parallel job e.g. MPI, OpenMP, or multi-threads is limited to 8
-cores. The `test`queue should be used when unsure of the job resource
+Different partitions on LOTUS have different allowed QoS as shown below:
+
+| Partition | Allowed QoS |
+| --- | --- |
+| `standard` | `standard`, `short`, `long`, `high`, `dask` |
+| `debug` | `debug` |
+{.table .table-striped .w-auto}
+
+A summary of the different QoS are below:
+
+| QoS | Priority | Max CPUs per job | Max wall time |
+| --- | --- | --- | --- |
+| `standard` | 500 | 1 | 24 hours |
+| `short` | 550 | 1 | 4 hours |
+| `long` | 350 | 1 | 5 days |
+| `high` | 450 | 96 | 2 days |
+| `debug` | 500 | 8 | 1 hour |
+{.table .table-striped .w-auto}
+
+Once you've chosen the partition and QoS you need, in your job script, provide the partition in the `--partition` directive and the QoS in the `--qos` directive.
+
+## How to choose a QoS
+
+### Debug QoS
+
+The `debug` QoS can be used to test new workflows and also to help new
+users to familiarise themselves with the Slurm batch system. This QoS should be used when unsure of the job resource
 requirements and behavior at runtime because it has a confined set of LOTUS
-nodes (Intel node type) not shared with the other standard LOTUS queues.
+nodes not shared with the other standard LOTUS queues.
 
-### Serial queues
+| QoS     | Priority | Max CPUs per job | Max wall time | Max jobs per user |
+|---------|----------|------------------|---------------|-------------------|
+| `debug` | 500      | 8                | 1 hour        | 32                |
+{.table .table-striped .w-auto}
 
-Serial and array jobs with a single CPU core should be submitted to one of the
-following serial queues depending on the job duration and the memory
-requirement. The default queue is `short-serial`
+### Standard QoS
 
-#### short-serial
+The `standard` QoS is the most common QoS to use, with a maximum of a single CPU per job and a runtime under 24 hours.
 
-Serial and/or array jobs with a single CPU core each and run time less than 24
-hrs should be submitted to the `short-serial` queue . This queue has the
-highest priority of 30. The maximum number of jobs that can be scheduled to
-start running from  the `short-serial` is 2000 jobs whilst  both job's
-resources are available and user' priority is high
+| QoS        | Priority | Max CPUs per job | Max wall time | Max jobs per user |
+|------------|----------|------------------|---------------|-------------------|
+| `standard` | 500      | 1                | 24 hours      | 4000              |
+{.table .table-striped .w-auto}
 
-#### long-serial
+### Short QoS
 
-Serial or array jobs with a single CPU core and run time greater than 24 hrs
-and less than 168 hrs (7 days) should be submitted to the queue `long-serial`
-.  This queue has the lowest priority of 10 and hence jobs might take longer
-to be scheduled to run relatively to other jobs in higher priority queues.
+The `short` QoS is for shorter jobs (under 4 hours) and has a maximum of a single CPU per job.
 
-#### high-mem
+| QoS     | Priority | Max CPUs per job | Max wall time | Max jobs per user |
+|---------|----------|------------------|---------------|-------------------|
+| `short` | 550      | 1                | 4 hours       | 2000              |
+{.table .table-striped .w-auto}
 
-Serial or array jobs with a single CPU core and high memory requirement (> 64
-GB) should be submitted to the `high-mem` queue and the required memory must
-be specified `--mem=XXX` (XXX is in MB units). The job should not exceed the
-maximum run time limit of 48hrs. This queue is not configured to accept
-exclusive jobs.
+### Long QoS
 
-### Parallel queues
+The `long` QoS is for jobs that will take longer than 24 hours but will have a lower priority than `standard`. It also has a maximum of a single CPU per job.
 
-Jobs requiring more than one CPU core should be submitted to one of the
-following parallel queues depending on the type of parallelisms such as shared
-memory or distributed memory jobs.
+| QoS     | Priority | Max CPUs per job | Max wall time | Max jobs per user |
+|---------|----------|------------------|---------------|-------------------|
+| `long`  | 350      | 1                | 5 days        | 1350              |
+{.table .table-striped .w-auto}
 
-#### par-single
+### High QoS
 
-Shared memory multi-threaded jobs with  a maximum  of 16 threads should be
-submitted to  the `par-single` queue . Each thread should be allocated one CPU
-core. Oversubscribing the number of threads to the CPU cores will cause the
-job to run very slow. The number of CPU cores should be specified via the
-submission command line `sbatch -n <number of CPU cores>` or  by adding the
-Slurm directive `#SBATCH -n <number of CPU cores>`in the job script file. An
-example is shown below:
+The `high` QoS is for jobs with larger resource requirements, for example CPUs per job and memory.
 
-{{<command>}}
-sbatch --ntasks=4 --partition=par-single < myjobscript
+| QoS     | Priority | Max CPUs per job | Max wall time |
+|---------|----------|------------------|---------------|
+| `high`  | 450      | 96               | 2 days        |
+{.table .table-striped .w-auto}
+
+## New Slurm job accounting hierarchy
+
+Slurm accounting by project has been introduced as a means of monitoring compute usage by projects on JASMIN. These projects align with group workspaces (GWSs), and you will automatically be added to Slurm accounts corresponding to any GWS projects that you belong to.
+
+To find what Slurm accounts and quality of services (QoS) that you have access to, use the `useraccounts` command on any `sci` machine.
+Output should be similar to one or more of the lines below.
+
+{{<command user="user" host="sci-ph-01">}}
+useraccounts
+(out)# sacctmgr show user fred withassoc format=user,account,qos%-50
+(out)User       Account        QOS
+(out)---------- -------------- -------------------------------------
+(out)      fred  mygws         debug,high,long,short,standard
+(out)      fred  orchid        debug,high,long,short,standard
 {{</command>}}
 
-Note: Jobs submitted with a number of CPU cores greater than 16 will be
-terminated (killed) by the Slurm scheduler with the following statement in the
-job output file:
+You should use the relevant account for your project's task with the `--account` directive in your job script.
 
-#### par-multi
-
-Distributed memory jobs with inter-node communication using the MPI library
-should be submitted to  the `par-multi` queue . A single MPI process (rank)
-should be allocated  a  single CPU core. The number of CPU cores should be
-specified via the Slurm submission command  flag `sbatch -n <number of CPU
-cores>` or  by adding the Slurm directive `#SBATCH -n <number of CPU cores>`
-to  the job script file. An example is shown below:
-
-{{<command>}}
-sbatch --ntasks=4 --partition=par-multi < myjobscript
-{{</command>}}
-
-Note 1: The number of CPU cores gets passed from Slurm submission  flag `-n` .
-Do not add  the `-np` flag  to `mpirun` command  .
-
-Note 2: Slurm will reject a job that requires a number of CPU cores greater
-than the limit of 256.
+Users who do not belong to any group workspaces will be assigned the `no-project` account and should use that in their job submissions.
+Please ignore and do not use the group `shobu`.

--- a/content/docs/batch-computing/slurm-queues.md
+++ b/content/docs/batch-computing/slurm-queues.md
@@ -11,22 +11,12 @@ tags:
 title: Slurm queues
 ---
 
-{{<alert type="danger">}}
-Not yet reviewed for compatibility with the new cluster, April 2025.
-Please adapt using [new submission instructions](how-to-submit-a-job-to-slurm). This alert will be removed once updated.
-{{</alert>}}
-
 ## Queue names
 
 The Slurm queues in the LOTUS cluster are:
 
-- `test`
-- `short-serial`
-- `long-serial`
-- `par-single`
-- `par-multi`
-- `high-mem`
-- `short-serial-4hr`
+- `standard`
+- `debug`
 
 Each queue is has attributes of run-length limits (e.g. short, long) and
 resources. A full breakdown of each queue and its associated resources is
@@ -45,32 +35,21 @@ job script file using Slurm scheduler directive like this:
 where `<queue_name>` is the name of the queue/partition (Table 1. column 1)
 
 Table 1 summarises important specifications for each queue such as run time
-limits and the number of CPU core limits. If the queue is not specified, Slurm
-will schedule the job to the queue `short-serial` by default.
+limits and memory limits.
 
 Table 1. LOTUS/Slurm queues and their specifications
 
-Queue name  |  Max run time  |  Default run time  |  Max CPU cores per job  |  MaxCpuPerUserLimit  |  Priority  
----|---|---|---|---|---  
-`test` |  4 hrs  |  1hr  |  8  |  8  |  30  
-`short-serial` |  24 hrs  |  1hr  |  1  |  2000  |  30  
-`par-single` |  48 hrs  |  1hr  |  16  |  300  |  25  
-`par-multi` |  48 hrs  |  1hr  |  256  |  300  |  20  
-`long-serial` |  168 hrs  |  1hr  |  1  |  300  |  10  
-`high-mem` |  48 hrs  |  1hr  |  1  |  75  |  30  
-`short-serial-4hr`<br>(**Note 3**)  |  4 hrs  |  1hr  |  1  |  1000  |  30
+| Queue name | Max run time | Default run time | Default memory per CPU |
+|------------|--------------|------------------|------------------------|
+| `standard` | 24 hrs       | 1hr              | 1GB                    |
+| `debug`    | 1 hr         | 30 mins          | 1GB                    |
 {.table .table-striped}
   
 **Note 1** : Resources requested by a job must be within the resource
 allocation limits of the selected queue.
 
-**Note 2:** The default value for `--time=[hh:mm:ss]` (predicted maximum wall
-time) is 1 hour for the all queues. If you do not specify this option
-and/or your job exceeds the default maximum run time limit then it will be
+**Note 2:** If your job exceeds the default maximum run time limit then it will be
 terminated by the Slurm scheduler.
-
-**Note 3** : A user must specify the Slurm job account `--account=short4hr`
-when submitting a batch job to the `short-serial-4hr` queue.
 
 ## State of queues
 

--- a/content/docs/batch-computing/slurm-quick-reference.md
+++ b/content/docs/batch-computing/slurm-quick-reference.md
@@ -23,7 +23,7 @@ and [ORCHID]({{% ref "orchid-gpu-cluster" %}}) (GPU) clusters.
 | ----------------------------------- | --------------------------------------- |
 | `sbatch my_batch_script.sh`         | Submit a job script to the scheduler    |
 | `sinfo`                             | Show available scheduling queues        |
-| `squeue -u <username>`              | List user's pending and running jobs    |
+| `squeue --me`                       | List my pending and running jobs        |
 | `salloc -p debug -q debug -A mygws` | Request an interactive session on LOTUS |
 {.table .table-striped}
   
@@ -39,19 +39,17 @@ Long and short argument names are separated by a comma.
 ##### `--account=GWS_NAME, -A GWS_NAME`
 
 - Specify which project's account to log the compute with by replacing `GWS_NAME`
-- To choose the right one, please read about the [new Slurm job accounting by project]({{% ref "how-to-submit-a-job-to-slurm/#new-slurm-job-accounting-hierarchy" %}})
+- To choose the right one, please read about the [new Slurm job accounting by project]({{% ref "slurm-queues/#new-slurm-job-accounting-hierarchy" %}})
 
 ##### `--partition=PARTITION_NAME, -p PARTITION_NAME`
 
 - Specify the scheduling partition by replacing `PARTITION_NAME`
-- See the [list of partitions]({{% ref "how-to-submit-a-job-to-slurm/#partitions-and-qos" %}}) that you can use
-<!-- Once updated, point to [Slurm queues page]({{% ref "slurm-queues" %}}) -->
+- See the [Slurm queues page]({{% ref "slurm-queues" %}}) for the list of partitions that you can use
 
 ##### `--qos=QOS_NAME, -q QOS_NAME`
 
 - Specify what Quality of Service your task needs by replacing `QOS_NAME`
-- See the [list of QoS]({{% ref "how-to-submit-a-job-to-slurm/#partitions-and-qos" %}}) that you can use
-<!-- Once updated, point to [Slurm queues page]({{% ref "slurm-queues" %}}) -->
+- See the [list of QoS]({{% ref "slurm-queues/#queues-and-qos" %}}) that you can use
 
 ##### `--time=hh:mm:ss, -t hh:mm:ss`
 
@@ -125,7 +123,7 @@ specify the unit, e.g. `--mem=5G` for 5 GB.
 | `scancel <jobid>`             | Kill a job                    |
 | `scontrol show job <jobid>`   | Show details job information  |
 | `scontrol update job <jobid>` | Modify a pending job          |
-| `scancel --user=<username>`   | Kill all jobs owned by a user |
+| `scancel --me`                | Kill all jobs owned by a user |
 {.table .table-striped}
   
 ## Job environment variables

--- a/content/docs/batch-computing/slurm-scheduler-overview.md
+++ b/content/docs/batch-computing/slurm-scheduler-overview.md
@@ -57,15 +57,13 @@ submissions to the LOTUS cluster: `standard` and `debug`. The default queue is
 `standard`. For testing new workflows, the `debug` queue is recommended.
 The queues are then further divided up into Quality of Services (QoS),
 which determine further restrictions about your job, for example, how long it can
-or how many CPU cores it can use.
+run or how many CPU cores it can use.
 
 The specification of each queue and its associated available QoS is
 described in detail in this article: [Slurm queues on LOTUS]({{% ref "slurm-queues" %}}).
 
 Queues other than the two standard queues should be
 ignored unless you have been specifically instructed to use them.
-
-<!-- Need to add here information about the QoS available -->
 
 ## The typical workflow for LOTUS jobs
 

--- a/content/docs/batch-computing/slurm-scheduler-overview.md
+++ b/content/docs/batch-computing/slurm-scheduler-overview.md
@@ -5,11 +5,6 @@ title: Slurm scheduler overview
 weight: 20
 ---
 
-{{<alert type="danger">}}
-Not yet reviewed for compatibility with the new cluster, April 2025.
-Please adapt using [new submission instructions](how-to-submit-a-job-to-slurm). This alert will be removed once updated.
-{{</alert>}}
-
 ## What is a Job Scheduler?
 
 A job or batch scheduler, is a tool that manages how user jobs
@@ -55,15 +50,19 @@ that become available. However, the orange and purple users already have jobs
 running, whereas the blue user does not, and as such it is the blue user's
 jobs that are run (bottom row).
 
-## LOTUS queues
-<!-- Queues to be updated -->
-There are five standard Slurm queues (also known as "partitions" in Slurm terminology) for batch job submissions to the LOTUS
-cluster: `short-serial`, `long-serial`, `par-single`, `par-multi` and `high-mem`.
-The default queue is `short-serial`. For testing new workflows, the
-additional queue `debug` is recommended. The specification of each queue is
+## LOTUS partitions
+
+There are two standard Slurm partitions (also known as "queues") for batch job 
+submissions to the LOTUS cluster: `standard` and `debug`. The default queue is
+`standard`. For testing new workflows, the `debug` queue is recommended.
+The queues are then further divided up into Quality of Services (QoS),
+which determine further restrictions about your job, for example, how long it can
+or how many CPU cores it can use.
+
+The specification of each queue and its associated available QoS is
 described in detail in this article: [Slurm queues on LOTUS]({{% ref "slurm-queues" %}}).
 
-Queues other than the five standard queues with the test queue should be
+Queues other than the two standard queues should be
 ignored unless you have been specifically instructed to use them.
 
 <!-- Need to add here information about the QoS available -->

--- a/content/docs/interactive-computing/dask-gateway.md
+++ b/content/docs/interactive-computing/dask-gateway.md
@@ -16,7 +16,7 @@ On JASMIN, it creates a Dask cluster in {{<link "../batch-computing/lotus-overvi
 Before using Dask Gateway on JASMIN, you will need:
 
 1. An existing JASMIN account and valid `jasmin-login` access role: {{<button size="sm" href="https://accounts.jasmin.ac.uk/services/login_services/jasmin-login/">}}Apply here{{</button>}}
-2. A Slurm account to log the Dask compute to. To choose the right one, please read about the [new Slurm job accounting by project]({{% ref "how-to-submit-a-job-to-slurm/#new-slurm-job-accounting-hierarchy" %}}).
+2. A Slurm account to log the Dask compute to. To choose the right one, please read about the [new Slurm job accounting by project]({{% ref "slurm-queues/#new-slurm-job-accounting-hierarchy" %}}).
 
 The `jasmin-login` access role ensures that your account is set up with access to the LOTUS batch processing cluster.
 

--- a/content/docs/software-on-jasmin/rocky9-migration-2024.md
+++ b/content/docs/software-on-jasmin/rocky9-migration-2024.md
@@ -260,7 +260,7 @@ special  | {{< icon fas triangle-exclamation text-danger >}} Not yet available |
 Notes:
 
 - \*2 CPU reserved for system processes
-- Overall ~55,000 cores: ~triples capacity pf previous cluster
+- Overall ~53,000 cores: ~triples capacity pf previous cluster (exact no. varies for operational reasons)
 - New nodes will form a new cluster, managed separately to the "old" LOTUS
 - Submission to the new cluster is now via any `sci-vm-*` or `sci-ph-*` node
 - 70% of old LOTUS has now been decommissioned
@@ -272,25 +272,3 @@ Please see the [updated LOTUS pages]({{% ref "batch-computing" %}}), including t
 
 **These require a [Slurm account]({{% ref "slurm-queues/#new-slurm-job-accounting-hierarchy" %}}), [partition and quality of service (QoS)]({{% ref "slurm-queues/#queues-and-qos" %}}) to be specified at job submission time**.
 {{</alert>}}
-
-### Timetable for host retirements
-
-Please find below a timetable of planned host retirements in line with our move to Rocky Linux 9. 
-
-Please start moving your work **NOW**
-so that any issues can be resolved and disruption minimized.
-
-| Host    | retirement date |
-| ---     | --- |
-| Group A | |
-| `cron1.ceda` aka `cron.jasmin`<br>`xfer3`<br>`nx-login[2,3]` | 21/11/2024 16:00 |
-| Group B | 
-| `nx4` aka `nx-login4` | 6/12/2024 16:00 |
-| Group C |
-| `xfer1`<br>`hpxfer1` - already shut down due to technical issue<br>`sci[1,2,4]`<br>`login[1,2]` | 6/12/2024 16:00 |
-| Group D | |
-| `xfer2`<br>`hpxfer2`<br>`sci[5,6,8]`<br>`login[3,4]`<br>`gridftp1`| 13/12/2024 16:00 |
-{.table .table-striped}
-
-All the hosts listed have new Rocky 9 equivalents described in the document above.
-Please check back regularly to keep up to date with this schedule.

--- a/content/docs/software-on-jasmin/rocky9-migration-2024.md
+++ b/content/docs/software-on-jasmin/rocky9-migration-2024.md
@@ -254,7 +254,7 @@ Preliminary node specification:
 type | status | specs
 --- | --- | ---
 standard | {{< icon fas circle-check text-success >}} Ready to use | 190* CPU AMD EPYC 9654 / 1.5 TB RAM / 480 GB SATA SSD + 800 GB NvMe SSD
-special (not yet available) | {{< icon fas circle-check text-success >}} Ready to use | 190* CPU AMD EPYC 9654 / 6 TB RAM / 480 GB SATA SSD + 800 GB NvMe SSD
+special  | {{< icon fas triangle-exclamation text-danger >}} Not yet available | 190* CPU AMD EPYC 9654 / 6 TB RAM / 480 GB SATA SSD + 800 GB NvMe SSD
 {.table .table-striped .w-auto}
 
 Notes:
@@ -268,93 +268,10 @@ Notes:
 ### New LOTUS2 cluster initial submission guide
 
 {{<alert type="info">}}
-Please see the details below on how to access LOTUS2 and how to submit a job to the new Slurm scheduling partitions.
+Please see the [updated LOTUS pages]({{% ref "batch-computing" %}}), including the [how to submit a job page]({{% ref "how-to-submit-a-job-to-slurm" %}}), to use the new Slurm scheduling partitions in LOTUS2.
 
-**These require a Slurm account, partition and quality of service (QoS) to be specified at job submission time**.
+**These require a [Slurm account]({{% ref "slurm-queues/#new-slurm-job-accounting-hierarchy" %}}), [partition and quality of service (QoS)]({{% ref "slurm-queues/#queues-and-qos" %}}) to be specified at job submission time**.
 {{</alert>}}
-
-#### New Slurm job accounting hierarchy
-
-Slurm accounting by project has been introduced as a means of monitoring compute usage by projects on JASMIN. These projects align with group workspaces (GWSs),
-and you will automatically be added to Slurm accounts corresponding to any GWS projects that you belong to.
-
-To find what Slurm accounts and quality of services that you have access to, use the `useraccounts` command on any `sci` machine.
-Output should be similar to one or more of the lines below.
-
-{{<command user="user" host="sci-ph-01">}}
-useraccounts
-(out)# sacctmgr show user fred withassoc format=user,account,qos%-50
-(out)User       Account        QOS
-(out)---------- -------------- --------------------------------------------------
-(out)      fred  mybiggws      debug,high,long,short,standard
-(out)      fred  orchid        debug,high,long,short,standard
-{{</command>}}
-
-Users who do not belong to any group workspaces will be assigned the `no-project` account and should use that in their job submissions.
-Please ignore and do not use the group `shobu`.
-
-#### Partitions and QoS
-
-There are two partitions currently available on LOTUS2, with associated allowed quality of service (QoS) as shown below:
-
-| Partition | Allowed QoS |
-| --- | --- |
-| `standard` | `standard`, `short`, `long` |
-| `debug` | `debug`, `reservation` |
-{.table .table-striped .w-auto}
-
-| QoS | Priority | Max CPUs per job | Max wall time |
-| --- | --- | --- | --- |
-| `standard` | 500 | 1 | 24 hours |
-| `short` | 550 | 1 | 4 hours |
-| `long` | 350 | 1 | 5 days |
-| `high` | 450 | 96 | 2 days |
-| `debug` | 500 | 8 | 1 hour |
-{.table .table-striped .w-auto}
-
-#### Job submission
-
-In order to successfully submit a job to LOTUS2, 3 mandatory fields must be specified. These are a partition, an account, and a QoS. The LOTUS2 configuration has been set to use the `standard` partition as the default if none is specified. However, users are discouraged from relying on the default.
-
-Example of a batch Script: **NB: remove any trailing whitespace**
-
-Replace `mygws` with the name of an account that you belong to (check with the `useraccounts` command, as shown above), and other values appropriate to your job.
-
-```bash
-#!/bin/bash
-#SBATCH --job-name="My test job"
-#SBATCH --time=00:01:00
-#SBATCH --mem=1M
-#SBATCH --account=mygws
-#SBATCH --partition=debug
-#SBATCH --qos=debug
-
-# rest of script here
-```
-
-where {{<link "https://slurm.schedmd.com/sbatch.html#OPT_time">}}`time`{{</link>}} and {{<link "https://slurm.schedmd.com/sbatch.html#OPT_mem" >}}mem{{</link>}} should be specified as per the `sbatch` documentation, which covers all available directives such as `--cpus-per-task`.
-
-Save this script file as e.g.`test_submit.sh`
-Then submit this with:
-
-{{<command user="user" host="sci-ph-01">}}
-sbatch test_submit.sh
-{{</command>}}
-
-For a pseudo-interactive session on a LOTUS2 compute node:
-
-(again, replace `mygws` with an account that you belong to, from the `useraccounts` command)
-
-{{<command user="user" host="sci-ph-01">}}
-srun --account=mygws --partition=debug --qos=debug --pty /bin/bash
-(out)srun: job 586 queued and waiting for resources
-(out)srun: job 586 has been allocated resources
-module li
-(out)
-(out)
-(out)Currently Loaded Modules:
-(out)1) idl/9.1
-{{</command>}}
 
 ### Timetable for host retirements
 


### PR DESCRIPTION
- Updated queues/partitions in slurm-queues
- Update LOTUS cluster specification, remove old host groups
- Move access to LOTUS troubleshooting to how-to-submit-a-job
- Move QoS and new Slurm accounting paragraph to Slurm queues page, update rest of page
- Update links that refer to moved QoS and new Slurm accounting info to the Slurm queues page
- Remove LOTUS2 initial submission guide from Rocky 9 page, link to updated Slurm pages
- Update ORCHID page with info about QoS and software
- Remove old partitions from MPI job page

Still todo:
- Rename queues to partitions everywhere
- Compiler info on MPI page is still unchecked for LOTUS2