### PR TITLE
Improve login problems, typos in getting started pages, tidy Slurm queues

### DIFF
--- a/content/docs/batch-computing/slurm-queues.md
+++ b/content/docs/batch-computing/slurm-queues.md
@@ -19,8 +19,8 @@ The Slurm queues in the LOTUS cluster are:
 - `debug`
 
 Each queue is has attributes of run-length limits (e.g. short, long) and
-resources. A full breakdown of each queue and its associated resources is
-shown below in Table 1.
+resources. A full breakdown of each queue and its associated resources, such as run time
+limits and memory limits, is shown below in Table 1.
 
 ## Queue details
 
@@ -32,20 +32,17 @@ job script file using Slurm scheduler directive like this:
 #SBATCH -p <partition=queue_name>
 ```
 
-where `<queue_name>` is the name of the queue/partition (Table 1. column 1)
+where `<queue_name>` is the name of the queue/partition (Table 1, column 1).
 
-Table 1 summarises important specifications for each queue such as run time
-limits and memory limits.
-
-Table 1. LOTUS/Slurm queues and their specifications
+**Table 1:** LOTUS/Slurm queues and their specifications
 
 | Queue name | Max run time | Default run time | Default memory per CPU |
 |------------|--------------|------------------|------------------------|
 | `standard` | 24 hrs       | 1hr              | 1GB                    |
 | `debug`    | 1 hr         | 30 mins          | 1GB                    |
 {.table .table-striped}
-  
-**Note 1** : Resources requested by a job must be within the resource
+
+**Note 1:** Resources requested by a job must be within the resource
 allocation limits of the selected queue.
 
 **Note 2:** If your job exceeds the default maximum run time limit then it will be
@@ -58,7 +55,7 @@ managed by Slurm. It has a wide variety of filtering, sorting, and formatting
 options.
 
 {{<command shell="bash" user="user" host="sci-ph-01">}}
-sinfo   
+sinfo
 (out)PARTITION AVAIL  TIMELIMIT  NODES STATE NODELIST
 (out)...
 (out)standard*    up 1-00:00:00    262  idle host[1004-1276]
@@ -75,15 +72,15 @@ as they implement different job scheduling and control policies.
 
 By default, the Slurm command `sinfo` displays the following information:
 
-- **PARTITION** : Partition name followed by `*` for the default queue/partition
-- **AVAIL** : State/availability of a queue/partition. Partition state: up or down.
-- **TIMELIMIT** : The maximum run time limit per job in each queue/partition is shown in `days-hours:minutes:seconds`, e.g. `2-00:00:00` is two days maximum runtime limit
-- **NODES** : Count of nodes with this particular configuration e.g. 48 nodes
-- **STATE** : State of the nodes. Possible states include: allocated, down, drained, and idle. For example, the state `idle` means that the node is not allocated to any jobs and is available for use.
-- **NODELIST** List of node names associated with this queue/partition
+- **PARTITION**: Partition name followed by `*` for the default queue/partition.
+- **AVAIL**: State/availability of a queue/partition. Partition state: up or down.
+- **TIMELIMIT**: The maximum run time limit per job in each queue/partition is shown in `days-hours:minutes:seconds`, e.g. `2-00:00:00` is two days maximum runtime limit.
+- **NODES**: Count of nodes with this particular configuration e.g. 48 nodes.
+- **STATE**: State of the nodes. Possible states include: allocated, down, drained, and idle. For example, the state `idle` means that the node is not allocated to any jobs and is available for use.
+- **NODELIST**: List of node names associated with this queue/partition.
 
 The `sinfo` example below, reports more complete information about the
-partition/queue `debug`
+partition/queue `debug`:
 
 {{<command user="user" host="sci-ph-01">}}
 sinfo --long --partition=debug
@@ -101,7 +98,7 @@ Different partitions on LOTUS have different allowed QoS as shown below:
 
 | Partition | Allowed QoS |
 | --- | --- |
-| `standard` | `standard`, `short`, `long`, `high`, `dask` |
+| `standard` | `standard`, `short`, `long`, `high` |
 | `debug` | `debug` |
 {.table .table-striped .w-auto}
 

--- a/content/docs/getting-started/get-login-account.md
+++ b/content/docs/getting-started/get-login-account.md
@@ -24,7 +24,7 @@ this service
 
 {{<image src="img/docs/get-login-account/login-services.png" caption="More information">}}
 
-**Step 2:** Apply for access to jasmin-login service
+**Step 2:** Apply for access to `jasmin-login` service
 
 {{<image src="img/docs/get-login-account/login-more-info.png" caption="Apply for jasmin-login">}}
 

--- a/content/docs/getting-started/how-to-login.md
+++ b/content/docs/getting-started/how-to-login.md
@@ -9,7 +9,7 @@ weight: 100
 ---
 
 The instructions below cover the process of logging in using a terminal client
-only. For a graphical linux desktop, please see alternative instructions using
+only. For a graphical Linux desktop, please see alternative instructions using
 [NoMachine NX]({{% ref "graphical-linux-desktop-access-using-nx" %}}).
 
 ## Preparing your credentials: loading your SSH private key
@@ -27,7 +27,7 @@ The details of how to do this can vary depending on whether your local machine
 runs Windows, macOS or Linux.
 
 {{<alert type="info">}}
-See [presenting your ssh key]({{%ref "present-ssh-key" %}}) for recommended methods
+See [presenting your SSH key]({{%ref "present-ssh-key" %}}) for recommended methods
 to present your SSH key, depending on what type of machine you are using.
 {{</alert>}}
 
@@ -112,13 +112,13 @@ ssh <user>@sci-vm-01.jasmin.ac.uk
 {{</command>}}
 
 If you are asked for a password when trying to login to this second machine,
-it indicates that your ssh key is not being forwarded. Please check that you
+it indicates that your SSH key is not being forwarded. Please check that you
 have used the `-A` option in your initial connection to the login server, or
 set up agent forwarding permanently in your SSH client configuration on your
 local machine.
 
 **There is no point in trying to enter a password (or even the passphrase
-associated with your key) as only an ssh key presented in the way described
+associated with your key) as only an SSH key presented in the way described
 above is accepted.**
 
 Note that once you are logged into a login server then you can omit the

--- a/content/docs/getting-started/present-ssh-key.md
+++ b/content/docs/getting-started/present-ssh-key.md
@@ -24,7 +24,7 @@ This simply involves including the `-i` option in the SSH command to specify the
 
 - Windows
   - Windows command or PowerShell terminal window (no additional software needed)
-  - MobaXterm (a 3rd party linux terminal emulator for windows, licence required)
+  - MobaXterm (a 3rd party Linux terminal emulator for windows, licence required)
   - PuTTy (a 3rd party suite of SSH tools including some GUI utilities)
 - Mac: "Terminal" or similar applications
 - Linux: "Terminal" or similar applications
@@ -190,7 +190,7 @@ Notes:
   
   ## Linux
 
-  Some linux terminal and desktop environments provide an ssh-agent as a graphical application: consult the 
+  Some Linux terminal and desktop environments provide an ssh-agent as a graphical application: consult the 
   documentation for your system.
 
   A common one is `gnome-keyring-daemon`: check for this first in your list of processes: if it's there and

--- a/content/docs/getting-started/present-ssh-key.md
+++ b/content/docs/getting-started/present-ssh-key.md
@@ -190,7 +190,6 @@ Notes:
   
   ## Linux
 
-
   Some Linux terminal and desktop environments provide an `ssh-agent` as a graphical application: consult the 
   documentation for your system.
 

--- a/content/docs/getting-started/update-a-jasmin-account.md
+++ b/content/docs/getting-started/update-a-jasmin-account.md
@@ -42,7 +42,7 @@ The system will reject any key that it recognises has been used before (across a
 
 Note: Please allow 15 minutes before attempting to log in again, while the new key becomes active on the JASMIN system.
 
-If you get the message "not a valid ssh public key" please check that you have
+If you get the message "not a valid SSH public key" please check that you have
 copied the text from the `.pub` file and that no newline characters are
 included: the public key should be a single line of text.
 It can be difficult to see this as the text automatically wraps

--- a/content/docs/interactive-computing/login-problems.md
+++ b/content/docs/interactive-computing/login-problems.md
@@ -53,15 +53,15 @@ number of reasons:
   * **You have not yet been granted jasmin-login access or your access has expired.**
     * To check, go to [My services](https://accounts.jasmin.ac.uk/services/my_services/?page=1&active=1&_apply_filters=1) on the JASMIN accounts portal and check that "Login services: jasmin-login" is listed. If not then you either need to [apply for jasmin-login access](https://accounts.jasmin.ac.uk/account/login/?next=/services/login_services/jasmin-login/), or if you have already done this recently you may simply need to wait for it to be approved. Note that if you have applied for access to a group workspace you still need jasmin-login access in order to connect to jasmin machines.
 
-**3) "The authenticity of host 'nnnn ( <ip address>)' can't be established."
+**3) "The authenticity of host 'nnnn (<ip address>)' can't be established."
 or "key for host nnnn has changed"**
 
 Your local computer stores a list of all the other SSH hosts which it has
 successfully connected to in the past. If you use an intermediate host like a
 login server to make onward connections to a sci machine, the login host will
 maintain another such list. In both cases there should be a
-file`~/.ssh/known_hosts` (so one in your local home directory on your own
-machine, and one in your JASMIIN home directory)
+`~/.ssh/known_hosts` file (so one in your local home directory on your own
+machine, and one in your JASMIIN home directory).
 
 When the SSH client first contacts the host for the SSH connection, it checks
 to see if the remote host is one that it recognises. If this check fails, you
@@ -132,7 +132,7 @@ Here, there are 3 main possibilities:
 
 **1) You have not set up agent forwarding correctly on your local machine.**
 
-****This allows your ssh key to be used for logging in from the login server to
+This allows your SSH key to be used for logging in from the login server to
 other machines. To check, run the following command on the login server:
 
 {{<command user="user" host="login-01">}}
@@ -149,7 +149,7 @@ If nothing is displayed then it indicates
 that agent forwarding is not working. Please read 
 [how to login]({{% ref "how-to-login" %}}) and make sure
  you are running ssh-agent (or similar), have loaded
-your private key and are using the `-A` option on your ssh command for the
+your private key and are using the `-A` option on your SSH command for the
 connection to the login server. NX users should make sure that the "agent
 forwarding" option is ticked when setting up a connection profile.
 
@@ -181,7 +181,7 @@ possible:
 - The date and time that you tried connecting (to the nearest minute if possible). This will help us to identify any relevant messages in any log files.
 - The exact command you were using
 - Add `-vvv` to your `ssh` command and send us the the output (please include the command itself)
-- List the SSH keys directory on your local machine. On a linux machine this can be done with the command: `ls -l ~/.ssh`
+- List the SSH keys directory on your local machine. On a Mac/Linux machine this can be done with the command: `ls -l ~/.ssh`
 
 ## ssh-add command gives error: "Could not open a connection to your authentication agent."
 

--- a/content/docs/interactive-computing/login-problems.md
+++ b/content/docs/interactive-computing/login-problems.md
@@ -46,12 +46,12 @@ number of reasons:
     * In this case, you will be attempting to connect with the username you have on your local machine, which may not be the same.
   * **You have only recently uploaded your SSH key (it can take 20 to 60 minutes before the key propagates to all the places it needs to on JASMIN).**
     * Try waiting a few minutes before trying again.
-  * **You don't have your key loaded in your local authentication agent (e.g. ssh-agent).**
+  * **You don't have your key presented or loaded in your local authentication agent (e.g. ssh-agent).**
     * Check that you are following the method suitable for your operating system
-      * The article "[How to login]({{% ref "how-to-login" %}})" has instructions for linux, mac and windows.  
-    * Note that connections using NoMachine NX don't require an authentication agent: this can be a good alternative if you're having problems.
-  * **You have not yet been granted jasmin-login access or your access has expired.**
-    * To check, go to [My services](https://accounts.jasmin.ac.uk/services/my_services/?page=1&active=1&_apply_filters=1) on the JASMIN accounts portal and check that "Login services: jasmin-login" is listed. If not then you either need to [apply for jasmin-login access](https://accounts.jasmin.ac.uk/account/login/?next=/services/login_services/jasmin-login/), or if you have already done this recently you may simply need to wait for it to be approved. Note that if you have applied for access to a group workspace you still need jasmin-login access in order to connect to jasmin machines.
+      * Please see the [presenting your SSH key]({{%ref "present-ssh-key" %}}) article for the recommended methods depending on what type of machine you are using.
+    * Note that connections using the [NoMachine client]({{% ref "graphical-linux-desktop-access-using-nx" %}}) don't require an authentication agent: this can be a good alternative if you're having problems.
+  * **You have not yet been granted `jasmin-login` access or your access has expired.**
+    * To check, go to [My services](https://accounts.jasmin.ac.uk/services/my_services/?page=1&active=1&_apply_filters=1) on the JASMIN accounts portal and check that `Login Services : jasmin-login` is listed with a green box and a tick like this: {{<icon fas square-check text-success>}} `USER`. If not, then you either need to [apply for or extend your `jasmin-login` access](https://accounts.jasmin.ac.uk/account/login/?next=/services/login_services/jasmin-login/). If you have already done this recently, you may simply need to wait for it to be approved. Note, that if you have been granted access to a group workspace, you still need `jasmin-login` access in order to connect to JASMIN machines.
 
 **3) "The authenticity of host 'nnnn (<ip address>)' can't be established."
 or "key for host nnnn has changed"**


### PR DESCRIPTION
- Improve reasons why permission denied errors occur on login problems page, including a link to the presenting SSH key page and explanation of active grants list
- Tidy spelling and typos of "Linux", "SSH", `jasmin-login` to be more consistent in getting started pages
- Tidy up Slurm queues page, remove duplicate info about the table of queues, formatting