### PR TITLE
Fix site build, removing mentions to NAG

### DIFF
--- a/content/docs/software-on-jasmin/idl.md
+++ b/content/docs/software-on-jasmin/idl.md
@@ -1,7 +1,7 @@
 ---
 aliases: /article/209-idl-and-midl
-description: IDL
-title: Using IDL on JASMIN
+description: Using IDL on JASMIN
+title: IDL
 ---
 
 ## What is IDL?

--- a/content/docs/software-on-jasmin/software-overview.md
+++ b/content/docs/software-on-jasmin/software-overview.md
@@ -26,7 +26,7 @@ There are a lot of different options when you are trying to work out which
 tools and/or environments to use on JASMIN. Here are some quick questions to
 help you get started:
 
-1\. Do you want to use NAME, JULES, MOOSE or the NAG libraries?
+1\. Do you want to use NAME, JULES, or MOOSE?
 
 - If yes, see: Restricted software
 

--- a/content/docs/uncategorized/working-with-many-linux-groups.md
+++ b/content/docs/uncategorized/working-with-many-linux-groups.md
@@ -32,8 +32,7 @@ which are mounted as type NFS, because this only supports 16 groups. In
 particular, this applies to the group workspaces that are optimised for small
 files (under path `/gws/smf`). It also applies to the home directories and
 `/apps` software directories, and although with these directories it is not
-normally necessary to restrict access via Linux groups, the restriction can
-affect for example access to the NAG library licence file for NERC users. The
+normally necessary to restrict access via Linux groups. The
 `panfs` filesystem type (Panasas group workspaces under `/group_workspaces`)
 is also affected in principle, but it has a limit of 32 groups, which is less
 likely to affect users.

--- a/data/docs.yml
+++ b/data/docs.yml
@@ -65,7 +65,6 @@
     - title: jasmin software faqs
     - title: jaspy envs
     - title: matplotlib
-    - title: nag library
     - title: name dispersion model
     - title: postgres databases on request
     - title: python virtual environments


### PR DESCRIPTION
Site was failing to build because the NAG page was removed but it was still in `data/docs.yml`. Removed further mentions too.