### PR TITLE
fix up references to old login nodes

### DIFF
--- a/content/docs/batch-computing/example-job-2-calc-md5s.md
+++ b/content/docs/batch-computing/example-job-2-calc-md5s.md
@@ -33,7 +33,7 @@ This is a simple case because:
 
 Log in to the `sci` server (use any of `sci-vm-0[1-6]`, access from a `login` server):
 
-{{<command user="user" host="login-01">}}
+{{<command user="user" host="login-NN">}}
 ssh -A <username>@sci-vm-01.jasmin.ac.uk
 {{</command>}}
 

--- a/content/docs/batch-computing/orchid-gpu-cluster.md
+++ b/content/docs/batch-computing/orchid-gpu-cluster.md
@@ -102,7 +102,7 @@ testing code prior to running as a batch job on ORCHID:
 
 Make sure that your initial SSH connection to the login server used the `-A` (agent forwarding) option, then:
 
-{{<command user="user" host="login-01">}}
+{{<command user="user" host="login-NN">}}
 ssh gpuhost001.jc.rl.ac.uk
 {{</command>}}
 

--- a/content/docs/getting-started/how-to-login.md
+++ b/content/docs/getting-started/how-to-login.md
@@ -49,7 +49,7 @@ ssh -A <user_id>@<login_server>
 For example, user `jpax` might login to a JASMIN login server with:
 
 {{<command user="user" host="localhost">}}
-ssh -A jpax@login-01.jasmin.ac.uk
+ssh -A jpax@login.jasmin.ac.uk
 {{</command>}}
 
 The `-A` **argument is important** because it enables "agent-forwarding".
@@ -66,7 +66,7 @@ SSH connections.
 When you first login you will see a message that provides some useful
 information (see Figure 1).
 
-{{<image src="img/docs/login/motd-labelled.png" caption="The login message shown on login-01.jasmin.ac.uk.">}}
+{{<image src="img/docs/login/motd-labelled.png" caption="The login message shown on login.jasmin.ac.uk.">}}
 
 ## X-forwarding for graphical applications (within JASMIN only)
 
@@ -107,7 +107,7 @@ under heavy usage.
 For example, from the JASMIN login server, you might choose to login to
 `sci-vm-01`:
 
-{{<command user="user" host="login-01">}}
+{{<command user="user" host="login-NN">}}
 ssh <user>@sci-vm-01.jasmin.ac.uk
 {{</command>}}
 
@@ -135,14 +135,14 @@ have finished your work, to get back to your own (local) machine:
 exit
 (out)logout
 {{</command>}}
-{{<command user="user" host="login-01">}}
+{{<command user="user" host="login-NN">}}
 (out)Connection to sci-vm-01.jasmin.ac.uk closed.
 exit
 (out)logout
 {{</command>}}
 {{<command user="user" host="localhost">}}
 #
-(out)Connection to login-01.jasmin.ac.uk closed.
+(out)Connection to login.jasmin.ac.uk closed.
 {{</command>}}
 
 You are then back on your own machine.

--- a/content/docs/interactive-computing/login-problems.md
+++ b/content/docs/interactive-computing/login-problems.md
@@ -20,7 +20,7 @@ resolve login problems. It provides information for the following issues:
 
 ## Unable to login to login server
 
-If you are unable to login to a login server e.g. `login-01.jasmin.ac.uk` then
+If you are unable to login to the login service on `login.jasmin.ac.uk` then
 look carefully at any error messages displayed as this can help diagnose what
 is wrong:
 
@@ -135,13 +135,13 @@ Here, there are 3 main possibilities:
 This allows your SSH key to be used for logging in from the login server to
 other machines. To check, run the following command on the login server:
 
-{{<command user="user" host="login-01">}}
+{{<command user="user" host="login-NN">}}
 echo "$SSH_AUTH_SOCK"
 {{</command>}}
 
 This should display something that looks similar to (but not identical to)
 
-{{<command user="user" host="login-01">}}
+{{<command user="user" host="login-NN">}}
 (out)/tmp/ssh-RNjiHr2844/agent.2844
 {{</command>}}
 

--- a/content/docs/interactive-computing/login-servers.md
+++ b/content/docs/interactive-computing/login-servers.md
@@ -7,23 +7,11 @@ title: Login servers
 weight: 30
 ---
 
-## Available login servers
+## Single login service
 
-There are four login servers available to access resources within JASMIN.
-Users with the `jasmin-login` access role can access the following servers via
+There is now a single login service to access resources within JASMIN.
+Users with the `jasmin-login` access role can access `login.jasmin.ac.uk` via
 {{<abbr SSH>}}.
-
-{{<alert alert-type="info" >}}
-All four login servers now have identical configuration and should be accessible from any network.
-{{</alert>}}
-
-name |
---- |
-`login-01.jasmin.ac.uk` |
-`login-02.jasmin.ac.uk` |
-`login-03.jasmin.ac.uk` |
-`login-04.jasmin.ac.uk` |
-{.table .table-striped .w-auto}
 
 ## Features of login servers
 
@@ -36,6 +24,7 @@ Login servers have minimal resources and software installed. They provide:
 
 ### Recent changes
 
+- With the single login service, connect to `login.jasmin.ac.uk` instead of choosing a numbered login server.  Your session will be assigned to one of the available numbered login servers on a load-sharing basis.  Your command prompt will show which server you are using, but note that you cannot connect to a numbered server directly.
 - There is no longer any requirement for forward/reverse DNS lookup or any restriction by
 institutional domain.
 - You no longer need to register non-`*.ac.uk` domains with the JASMIN team.
@@ -76,9 +65,9 @@ The connection via a login server can be done either with 2 hops, or using a log
 - 2 hops method:
 
 {{<command user="user" host="localhost">}}
-ssh -A fred@login-01.jasmin.ac.uk
+ssh -A fred@login.jasmin.ac.uk
 {{</command>}}
-{{<command user="fred" host="login-01">}}
+{{<command user="fred" host="login-NN">}}
 ssh fred@sci-vm-01.jasmin.ac.uk
 ## no -A needed for this step, if no onward connections from sci server
 {{</command>}}
@@ -89,7 +78,7 @@ ssh fred@sci-vm-01.jasmin.ac.uk
 - Jump Host method:
 
 {{<command user="user" host="localhost">}}
-ssh -A fred@sci-vm-01.jasmin.ac.uk -J fred@login-01.jasmin.ac.uk
+ssh -A fred@sci-vm-01.jasmin.ac.uk -J fred@login.jasmin.ac.uk
 {{</command>}}
 {{<command user="fred" host="sci-vm-01">}}
 ## now on sci server
@@ -98,17 +87,17 @@ ssh -A fred@sci-vm-01.jasmin.ac.uk -J fred@login-01.jasmin.ac.uk
 Alternatively, the same effect can be achieved with a ProxyJump directive in your local `~/.ssh/config` file:
 
 ```config
-Host Sci1ViaLogin01
+Host Sci1ViaLogin
   User fred
   ForwardAgent yes
   HostName sci-vm-01.jasmin.ac.uk
-  ProxyJump fred@login-01.jasmin.ac.uk
+  ProxyJump fred@login.jasmin.ac.uk
 ```
 
-You could then simply connect to `Sci1ViaLogin01`:
+You could then simply connect to `Sci1ViaLogin`:
 
 {{<command user="user" host="localhost">}}
-ssh Sci1ViaLogin01
+ssh Sci1ViaLogin
 {{</command>}}
 {{<command user="fred" host="sci-vm-01">}}
 ## now on sci server
@@ -122,10 +111,10 @@ Host *.jasmin.ac.uk
   ForwardAgent yes
 
 Host *.jasmin.ac.uk !login*.jasmin.ac.uk !xfer*.jasmin.ac.uk !nx*.jasmin.ac.uk
-  ProxyJump login-01.jasmin.ac.uk
+  ProxyJump login.jasmin.ac.uk
 ```
 
-Then you when you connect to any JASMIN host (other than a login or transfer host), it will go via login-01:
+Then you when you connect to any JASMIN host (other than a login or transfer host), it will go via `login.jasmin.ac.uk`:
 
 {{<command user="user" host="localhost">}}
 ssh sci-vm-01.jasmin.ac.uk
@@ -148,11 +137,11 @@ An alternative is to include a line specifying
 the location of your key, so you'll then be prompted for your passphrase whenever you connect:
 
 ```config
-Host Sci1ViaLogin01
+Host Sci1ViaLogin
   User fred
   ForwardAgent yes
   HostName sci-vm-01.jasmin.ac.uk
-  ProxyJump fred@login-01.jasmin.ac.uk
+  ProxyJump fred@login.jasmin.ac.uk
   IdentityFile ~/.ssh/id_ecdsa_jasmin
 ```
 

--- a/content/docs/interactive-computing/login-servers.md
+++ b/content/docs/interactive-computing/login-servers.md
@@ -15,22 +15,22 @@ Users with the `jasmin-login` access role can access `login.jasmin.ac.uk` via
 
 ## Features of login servers
 
-Login servers have minimal resources and software installed. They provide:
+Login servers have minimal resources and no software installed. They provide:
 
 - a means to access other resources within JASMIN (inside the {{<abbr STFC >}} firewall)
 - access to your home directory (`/home/users/<username>`)
 - no analysis software
-- no access to group workspaces
+- no access to group workspaces or other file systems
 
 ### Recent changes
 
 - With the single login service, connect to `login.jasmin.ac.uk` instead of choosing a numbered login server.  Your session will be assigned to one of the available numbered login servers on a load-sharing basis.  Your command prompt will show which server you are using, but note that you cannot connect to a numbered server directly.
+- Some users may need to run `ssh-keygen -R login.jasmin.ac.uk` first to remove previous host key entries for that name from their `~/.ssh/authorized_keys`.
 - There is no longer any requirement for forward/reverse DNS lookup or any restriction by
 institutional domain.
 - You no longer need to register non-`*.ac.uk` domains with the JASMIN team.
 - This means all users can access all login servers (previously some users could only use particular ones)
-- As before, no filesystems other than the home directory are mounted.
-- Use only as a "hop" to reach other servers within JASMIN.
+- Use only as a "hop" to reach other servers within JASMIN - **do not run any processes on a login server**.
 - **Make sure your SSH client is up to date**. Check the version with `ssh -V`. If
 it's significantly older than `OpenSSH_8.7p1, OpenSSL 3.0.7`, speak to your local
 admin team as it may need to be updated before you can connect securely to JASMIN.
@@ -84,7 +84,7 @@ ssh -A fred@sci-vm-01.jasmin.ac.uk -J fred@login.jasmin.ac.uk
 ## now on sci server
 {{</command>}}
 
-Alternatively, the same effect can be achieved with a ProxyJump directive in your local `~/.ssh/config` file:
+Alternatively, the same effect can be achieved with a `ProxyJump` directive in your local `~/.ssh/config` file:
 
 ```config
 Host Sci1ViaLogin

--- a/content/docs/mass/external-access-to-mass-faq.md
+++ b/content/docs/mass/external-access-to-mass-faq.md
@@ -50,7 +50,7 @@ method to check is to verify if you are a member of the `moose` user group. It
 should be listed when you use the ‘groups’ command:
 
 ```
-[login1]$ groups
+[user@login-NN ~]$ groups
 moose
 ```
 If this happens, please contact:
@@ -61,7 +61,7 @@ node. You can test for this condition by listing loaded identities on the
 login node, and finding you have none:
 
 ```
-[login1]$ ssh-add -l
+[user@login-NN ~]$ ssh-add -l
 Could not open a connection to your authentication agent.
 ```
 
@@ -80,7 +80,7 @@ file):
 Host mass-cli 
     User your_jasmin_userid 
     HostName mass-cli.jasmin.ac.uk
-    ProxyCommand ssh -YA -t your_jasmin_userid@login1.jasmin.ac.uk -W %h:%p 2>/dev/null
+    ProxyCommand ssh -YA -t your_jasmin_userid@login.jasmin.ac.uk -W %h:%p 2>/dev/null
 ```
 
 You should then be able to login directly using:

--- a/content/docs/mass/external-access-to-mass-faq.md
+++ b/content/docs/mass/external-access-to-mass-faq.md
@@ -49,21 +49,22 @@ The first is if you do not have permission to access the machine. A quick
 method to check is to verify if you are a member of the `moose` user group. It
 should be listed when you use the ‘groups’ command:
 
-```
-[user@login-NN ~]$ groups
-moose
-```
+{{<command user="user" host="login-NN">}}
+groups
+(out)moose
+{{</command>}}
+
 If this happens, please contact:
 [Monsoon@metoffice.gov.uk](mailto:Monsoon@metoffice.gov.uk)
 
-The second is if you forget the `-A` option for agent forwarind when you ssh to a JASMIN login
+The second is if you forget the `-A` option for agent forwarding when you ssh to a JASMIN login
 node. You can test for this condition by listing loaded identities on the
 login node, and finding you have none:
 
-```
-[user@login-NN ~]$ ssh-add -l
-Could not open a connection to your authentication agent.
-```
+{{<command user="user" host="login-NN">}}
+ssh-add -l
+(out)Could not open a connection to your authentication agent.
+{{</command>}}
 
 If this happens, please exit back to your local machine and ssh in again using
 the `-A` flag or tick the relevant box for "agent forwarding".

--- a/content/docs/mass/setting-up-your-jasmin-account-for-access-to-mass.md
+++ b/content/docs/mass/setting-up-your-jasmin-account-for-access-to-mass.md
@@ -35,14 +35,14 @@ keep your SSH client up to date in order to be able to connect securely to JASMI
 In your terminal window:
 
 {{<command user="localuser" host="localhost">}}
-ssh -A -X <userid>@login-01.jasmin.ac.uk
+ssh -A -X <userid>@login.jasmin.ac.uk
 {{</command>}}
 
 ## Test login to the MASS client host
 
 From the login machine, you can now make the onward connection to the "MASS client" host.
 
-{{<command user="user" host="login-01">}}
+{{<command user="user" host="login-NN">}}
 ssh -X <userid>@mass-cli.jasmin.ac.uk
 {{</command>}}
 {{<command user="user" host="mass-cli">}}
@@ -50,7 +50,7 @@ echo "Hello World"
 (out)Hello World
 exit
 {{</command>}}
-{{<command user="user" host="login-01">}}
+{{<command user="user" host="login-NN">}}
 exit
 {{</command>}}
 {{<command user="localuser" host="localhost">}}
@@ -75,9 +75,9 @@ Start on your local machine, where you should have the credentials file:
 
 {{<command user="user" host="localhost">}}
 scp moose <userid>@xfer-vm-01.jasmin.ac.uk:~/moose
-ssh -A -X <userid>@login-01.jasmin.ac.uk
+ssh -A -X <userid>@login.jasmin.ac.uk
 {{</command>}}
-{{<command user="user" host="login-01">}}
+{{<command user="user" host="login-NN">}}
 ssh -X <userid>@mass-cli.jasmin.ac.uk
 {{</command>}}
 

--- a/content/docs/software-on-jasmin/rocky9-migration-2024.md
+++ b/content/docs/software-on-jasmin/rocky9-migration-2024.md
@@ -58,14 +58,8 @@ but have been influenced by a number of factors including:
 
 ### Login nodes
 
-The list of new login nodes is as follows:
+Use the single login service on `login.jasmin.ac.uk`.  Your session will be assigned to one of the available login nodes.
 
-name | status
---- | ---
-`login-01.jasmin.ac.uk` | {{< icon fas circle-check text-success >}} ready to use
-`login-02.jasmin.ac.uk` | {{< icon fas circle-check text-success >}} ready to use
-`login-03.jasmin.ac.uk` | {{< icon fas circle-check text-success >}} ready to use
-`login-04.jasmin.ac.uk` | {{< icon fas circle-check text-success >}} ready to use
 {.table .table-striped .w-auto}
 
 Notes:

--- a/content/docs/uncategorized/mobaxterm.md
+++ b/content/docs/uncategorized/mobaxterm.md
@@ -117,13 +117,12 @@ button.
 Next, try connecting to the login server:
 
 {{<command user="user" host="mobaxterm">}}
-ssh -A <user_id>@login-01.jasmin.ac.uk
+ssh -A <user_id>@login.jasmin.ac.uk
 {{</command>}}
 
 Notes:
 
 - replace `<user_id>` with your own JASMIN username)
-- check the list of available [login servers]({{% ref "login-servers" %}}): you don't have to use the one above!
 
 ## Logging in to JASMIN without storing your key in MobAgent
 
@@ -150,7 +149,7 @@ You will need to do this each time you open a new terminal session. To connect
 to JASMIN:
 
 {{<command user="user" host="mobaxterm">}}
-ssh -A <user_id>@login-01.jasmin.ac.uk
+ssh -A <user_id>@login.jasmin.ac.uk
 {{</command>}}
 
 Again, you must replace `<user_id>` with your JASMIN username.


### PR DESCRIPTION
Change various references to login nodes, to reflect the new single login service.

Mostly to `login.jasmin.ac.uk`, although where the command prompt that the user will see is represented, `login-NN` is used.  (In practice this will be e.g. `login-07` but do not show any particular number, in order to avoid suggesting that these can be accessed directly.)