### PR TITLE
login machine name

### DIFF
--- a/content/docs/getting-started/how-to-login.md
+++ b/content/docs/getting-started/how-to-login.md
@@ -43,7 +43,7 @@ Assuming that you have loaded your SSH private key using one of the methods
 described above, then you can login to a login server as follows (do this on your own/local machine):
 
 {{<command user="user" host="localhost">}}
-ssh -A <user_id>@<login_server>
+ssh -A <user_id>@login.jasmin.ac.uk
 {{</command>}}
 
 For example, user `jpax` might login to a JASMIN login server with:


### PR DESCRIPTION
user should connect to `login.jasmin.ac.uk` rather than a chosen login server explicitly