### PR TITLE
Open permissions

### DIFF
--- a/content/docs/getting-started/how-to-login.md
+++ b/content/docs/getting-started/how-to-login.md
@@ -43,7 +43,7 @@ Assuming that you have loaded your SSH private key using one of the methods
 described above, then you can login to a login server as follows (do this on your own/local machine):
 
 {{<command user="user" host="localhost">}}
-ssh -A <user_id>@<login_server>
+ssh -A <user_id>@login.jasmin.ac.uk
 {{</command>}}
 
 For example, user `jpax` might login to a JASMIN login server with:

--- a/content/docs/getting-started/permissions-groups.md
+++ b/content/docs/getting-started/permissions-groups.md
@@ -328,7 +328,7 @@ otherwise any group-level permissions would apply to the wrong group.
 {{<alert alert-type="danger">}}
 Do not set "world-writable" permissions on files or directories, for example:
 
-`-rw-rw-rw-` for a file, or **<< DON'T USE THESE!!**
+`-rw-rw-rw-` for a file, or **<< DON'T USE THESE!!**<br>
 `drwxrwxrwx` for a directory. **<< DON'T USE THESE!!**
 
 We provide a UNIX a group corresponding to each group workspace, usually named `gws_<name>` which all members of that GWS belong to: this enables sharing within the group if you set permissions appropriately using that group.  This may include group-writable permissions where appropriate, for example:

--- a/content/docs/getting-started/permissions-groups.md
+++ b/content/docs/getting-started/permissions-groups.md
@@ -325,20 +325,18 @@ otherwise any group-level permissions would apply to the wrong group.
 
 ## Unsafe permissions
 
-{{<alert alert-type="danger">}}Do not set open permissions on files or
-directories. By "open" we mean where data are writable by the "other"
-group, for example:
+{{<alert alert-type="danger">}}
+Do not set "world-writable" permissions on files or directories, for example:
 
-`-rw-rw-rw-` **<< DON'T DO THIS!!**<br>
-`drwxrwxrwx` **<< OR THIS!!**
+`-rw-rw-rw-` for a file, or **<< DON'T USE THESE!!**
+`drwxrwxrwx` for a directory. **<< DON'T USE THESE!!**
 
-This would mean that any user with access to the same file system could
-modify or delete your data: this is a security risk.
+We provide a UNIX a group corresponding to each group workspace, usually named `gws_<name>` which all members of that GWS belong to: this enables sharing within the group if you set permissions appropriately using that group.  This may include group-writable permissions where appropriate, for example:
 
-We provide a UNIX a group corresponding to each group workspace, which all
-members of that GWS belong to: this enables sharing within the group if you set
-permissions appropriately using the advice in this guide. If you are unsure
-about setting permissions, please ask the helpdesk.
+`-rw-rw-r--` for a file
+`drwxrwxr-x` for a directory
+
+If you are unsure about setting permissions, please ask the helpdesk.
 
 **Where we (JASMIN administrators) encounter unsafe permissions on JASMIN,
 we may take action to revert permissions to a safe state.**

--- a/content/docs/getting-started/permissions-groups.md
+++ b/content/docs/getting-started/permissions-groups.md
@@ -333,7 +333,7 @@ Do not set "world-writable" permissions on files or directories, for example:
 
 We provide a UNIX a group corresponding to each group workspace, usually named `gws_<name>` which all members of that GWS belong to: this enables sharing within the group if you set permissions appropriately using that group.  This may include group-writable permissions where appropriate, for example:
 
-`-rw-rw-r--` for a file
+`-rw-rw-r--` for a file<br>
 `drwxrwxr-x` for a directory
 
 If you are unsure about setting permissions, please ask the helpdesk.

--- a/content/docs/getting-started/permissions-groups.md
+++ b/content/docs/getting-started/permissions-groups.md
@@ -325,19 +325,27 @@ otherwise any group-level permissions would apply to the wrong group.
 
 ## Unsafe permissions
 
-{{<alert alert-type="danger">}}
+{{<alert color="danger" icon="fas circle-xmark">}}
 Do not set "world-writable" permissions on files or directories, for example:
 
 `-rw-rw-rw-` for a file, or **<< DON'T USE THESE!!**<br>
 `drwxrwxrwx` for a directory. **<< DON'T USE THESE!!**
 
-We provide a UNIX a group corresponding to each group workspace, usually named `gws_<name>` which all members of that GWS belong to: this enables sharing within the group if you set permissions appropriately using that group.  This may include group-writable permissions where appropriate, for example:
+{{</alert>}}
+
+We provide a UNIX group corresponding to each group workspace, usually named `gws_<name>` which all members of that GWS belong to: this enables sharing within the group.
+
+{{<alert color="success" icon="fas circle-check">}}
+
+To set permissions appropriately using your `gws_<name>` group, you may want to use the group-writable flag, for example:
 
 `-rw-rw-r--` for a file<br>
 `drwxrwxr-x` for a directory
+
+{{</alert>}}
 
 If you are unsure about setting permissions, please ask the helpdesk.
 
 **Where we (JASMIN administrators) encounter unsafe permissions on JASMIN,
 we may take action to revert permissions to a safe state.**
-{{</alert>}}
+

--- a/content/docs/short-term-project-storage/managing-a-gws.md
+++ b/content/docs/short-term-project-storage/managing-a-gws.md
@@ -235,7 +235,7 @@ Do not set, or allow your users to set, "world-writable" permissions on files or
 
 We provide a UNIX a group corresponding to each group workspace, usually named `gws_<name>` which all members of that GWS belong to: this enables sharing within the group if you set permissions appropriately using that group.  This may include group-writable permissions where appropriate, for example:
 
-`-rw-rw-r--` for a file
+`-rw-rw-r--` for a file<br>
 `drwxrwxr-x` for a directory
 
 If you are unsure about setting permissions, please ask the helpdesk.

--- a/content/docs/short-term-project-storage/managing-a-gws.md
+++ b/content/docs/short-term-project-storage/managing-a-gws.md
@@ -230,7 +230,7 @@ store any data of a personal or sensitive nature in the GWS.
 {{< alert alert-type="danger" >}}
 Do not set, or allow your users to set, "world-writable" permissions on files or directories, for example:
 
-`-rw-rw-rw-` for a file, or **<< DON'T USE THESE!!**
+`-rw-rw-rw-` for a file, or **<< DON'T USE THESE!!**<br>
 `drwxrwxrwx` for a directory. **<< DON'T USE THESE!!**
 
 We provide a UNIX a group corresponding to each group workspace, usually named `gws_<name>` which all members of that GWS belong to: this enables sharing within the group if you set permissions appropriately using that group.  This may include group-writable permissions where appropriate, for example:

--- a/content/docs/short-term-project-storage/managing-a-gws.md
+++ b/content/docs/short-term-project-storage/managing-a-gws.md
@@ -228,13 +228,17 @@ data may be stored in the GWS or anywhere else within JASMIN. Users should not
 store any data of a personal or sensitive nature in the GWS.
 
 {{< alert alert-type="danger" >}}
-Do not set, or allow your users to set, open permissions on files or directories.
-By this we mean permissions where data are "world-writable" by anyone, for example
+Do not set, or allow your users to set, "world-writable" permissions on files or directories, for example:
 
-`-rw-rw-rw-` for a file, or **<< DON'T USE THESE!!**<br>
-`drwxrwxrwx` for a directory. **<< OR THESE!!**
+`-rw-rw-rw-` for a file, or **<< DON'T USE THESE!!**
+`drwxrwxrwx` for a directory. **<< DON'T USE THESE!!**
 
-We provide a UNIX a group corresponding to each group workspace, which all members of that GWS belong to: this enables sharing within the group if you set permissions appropriately using that group. If you are unsure about setting permissions, please ask the helpdesk.
+We provide a UNIX a group corresponding to each group workspace, usually named `gws_<name>` which all members of that GWS belong to: this enables sharing within the group if you set permissions appropriately using that group.  This may include group-writable permissions where appropriate, for example:
+
+`-rw-rw-r--` for a file
+`drwxrwxr-x` for a directory
+
+If you are unsure about setting permissions, please ask the helpdesk.
 {{< /alert >}}
 
 ## Changing ownership of files in your GWS

--- a/content/docs/short-term-project-storage/managing-a-gws.md
+++ b/content/docs/short-term-project-storage/managing-a-gws.md
@@ -227,19 +227,26 @@ by removal of user access. No offensive, obscene or otherwise unauthorised
 data may be stored in the GWS or anywhere else within JASMIN. Users should not
 store any data of a personal or sensitive nature in the GWS.
 
-{{< alert alert-type="danger" >}}
-Do not set, or allow your users to set, "world-writable" permissions on files or directories, for example:
+{{<alert color="danger" icon="fas circle-xmark">}}
+Do not set "world-writable" permissions on files or directories, for example:
 
 `-rw-rw-rw-` for a file, or **<< DON'T USE THESE!!**<br>
 `drwxrwxrwx` for a directory. **<< DON'T USE THESE!!**
 
-We provide a UNIX a group corresponding to each group workspace, usually named `gws_<name>` which all members of that GWS belong to: this enables sharing within the group if you set permissions appropriately using that group.  This may include group-writable permissions where appropriate, for example:
+{{</alert>}}
+
+We provide a UNIX group corresponding to each group workspace, usually named `gws_<name>` which all members of that GWS belong to: this enables sharing within the group.
+
+{{<alert color="success" icon="fas circle-check">}}
+
+To set permissions appropriately using your `gws_<name>` group, you may want to use the group-writable flag, for example:
 
 `-rw-rw-r--` for a file<br>
 `drwxrwxr-x` for a directory
 
+{{</alert>}}
+
 If you are unsure about setting permissions, please ask the helpdesk.
-{{< /alert >}}
 
 ## Changing ownership of files in your GWS
 

--- a/content/docs/short-term-project-storage/share-gws-data-on-jasmin.md
+++ b/content/docs/short-term-project-storage/share-gws-data-on-jasmin.md
@@ -59,7 +59,7 @@ chmod o+x /group_workspaces/jasmin/superproj/public
 {{< alert alert-type="danger" >}}
 Do not set "world-writable" permissions on files or directories, for example:
 
-`-rw-rw-rw-` for a file, or **<< DON'T USE THESE!!**
+`-rw-rw-rw-` for a file, or **<< DON'T USE THESE!!**<br>
 `drwxrwxrwx` for a directory. **<< DON'T USE THESE!!**
 
 We provide a UNIX a group corresponding to each group workspace, usually named `gws_<name>` which all members of that GWS belong to: this enables sharing within the group if you set permissions appropriately using that group.  This may include group-writable permissions where appropriate, for example:

--- a/content/docs/short-term-project-storage/share-gws-data-on-jasmin.md
+++ b/content/docs/short-term-project-storage/share-gws-data-on-jasmin.md
@@ -57,12 +57,15 @@ chmod o+x /group_workspaces/jasmin/superproj/public
 {{</command>}}
 
 {{< alert alert-type="danger" >}}
-Do not set open permissions on files or directories.
-By this we mean permissions where data are "world-writable" by anyone, for example
+Do not set "world-writable" permissions on files or directories, for example:
 
 `-rw-rw-rw-` for a file, or **<< DON'T USE THESE!!**
-
 `drwxrwxrwx` for a directory. **<< DON'T USE THESE!!**
 
-We provide a UNIX a group corresponding to each group workspace, usually named `gws_<name>` which all members of that GWS belong to: this enables sharing within the group if you set permissions appropriately using that group. If you are unsure about setting permissions, please ask the helpdesk.
+We provide a UNIX a group corresponding to each group workspace, usually named `gws_<name>` which all members of that GWS belong to: this enables sharing within the group if you set permissions appropriately using that group.  This may include group-writable permissions where appropriate, for example:
+
+`-rw-rw-r--` for a file
+`drwxrwxr-x` for a directory
+
+If you are unsure about setting permissions, please ask the helpdesk.
 {{</alert>}}

--- a/content/docs/short-term-project-storage/share-gws-data-on-jasmin.md
+++ b/content/docs/short-term-project-storage/share-gws-data-on-jasmin.md
@@ -64,7 +64,7 @@ Do not set "world-writable" permissions on files or directories, for example:
 
 We provide a UNIX a group corresponding to each group workspace, usually named `gws_<name>` which all members of that GWS belong to: this enables sharing within the group if you set permissions appropriately using that group.  This may include group-writable permissions where appropriate, for example:
 
-`-rw-rw-r--` for a file
+`-rw-rw-r--` for a file<br>
 `drwxrwxr-x` for a directory
 
 If you are unsure about setting permissions, please ask the helpdesk.

--- a/content/docs/short-term-project-storage/share-gws-data-on-jasmin.md
+++ b/content/docs/short-term-project-storage/share-gws-data-on-jasmin.md
@@ -56,16 +56,23 @@ you may wish to re-add execute permission on that directory, e.g.:
 chmod o+x /group_workspaces/jasmin/superproj/public
 {{</command>}}
 
-{{< alert alert-type="danger" >}}
+{{<alert color="danger" icon="fas circle-xmark">}}
 Do not set "world-writable" permissions on files or directories, for example:
 
 `-rw-rw-rw-` for a file, or **<< DON'T USE THESE!!**<br>
 `drwxrwxrwx` for a directory. **<< DON'T USE THESE!!**
 
-We provide a UNIX a group corresponding to each group workspace, usually named `gws_<name>` which all members of that GWS belong to: this enables sharing within the group if you set permissions appropriately using that group.  This may include group-writable permissions where appropriate, for example:
+{{</alert>}}
+
+We provide a UNIX group corresponding to each group workspace, usually named `gws_<name>` which all members of that GWS belong to: this enables sharing within the group.
+
+{{<alert color="success" icon="fas circle-check">}}
+
+To set permissions appropriately using your `gws_<name>` group, you may want to use the group-writable flag, for example:
 
 `-rw-rw-r--` for a file<br>
 `drwxrwxr-x` for a directory
 
-If you are unsure about setting permissions, please ask the helpdesk.
 {{</alert>}}
+
+If you are unsure about setting permissions, please ask the helpdesk.


### PR DESCRIPTION
Clarify wording regarding not setting open permissions.

 - avoids reference to _the "other" group_ - could be confusing because "other" is not a group in the Linux sense
 - avoids the word "open", which then needs to be clarified to avoid it being misunderstood as including read permissions - instead, focuses directly on write permissions
 - clarifies that group-write is still allowed where appropriate (in the context of the GWS group)