### PR TITLE
Fix alert link underlines to improve readability

### DIFF
--- a/assets/scss/components/_alert.scss
+++ b/assets/scss/components/_alert.scss
@@ -1,0 +1,20 @@
+.alert code {
+    color: inherit;
+}
+
+/* stylelint-disable declaration-block-no-redundant-longhand-properties */
+.alert a {
+    color: inherit;
+    
+    &:link,
+    &:visited,
+    &:hover,
+    &:active {
+        text-decoration-line: underline;
+        text-decoration-thickness: 10%;
+        // text-decoration-style: dashed;
+        // text-decoration-color: var(--bs-body);
+        text-decoration-color: var(--bs-primary);
+    }    
+}
+/* stylelint-enable declaration-block-no-redundant-longhand-properties */

--- a/assets/scss/components/_alert.scss
+++ b/assets/scss/components/_alert.scss
@@ -8,13 +8,17 @@
     
     &:link,
     &:visited,
-    &:hover,
     &:active {
         text-decoration-line: underline;
+        text-decoration-style: dotted;
         text-decoration-thickness: 10%;
-        // text-decoration-style: dashed;
-        // text-decoration-color: var(--bs-body);
-        text-decoration-color: var(--bs-primary);
-    }    
+    }
+
+    &:hover {
+        text-decoration-line: underline;
+        text-decoration-style: solid;
+        text-decoration-thickness: 10%;
+        opacity: 0.5;
+    }
 }
 /* stylelint-enable declaration-block-no-redundant-longhand-properties */

--- a/content/docs/getting-started/how-to-login.md
+++ b/content/docs/getting-started/how-to-login.md
@@ -27,7 +27,7 @@ The details of how to do this can vary depending on whether your local machine
 runs Windows, macOS or Linux.
 
 {{<alert alert-type="info">}}
-See [presenting your SSH key]({{%ref "present-ssh-key" %}}) for recommended methods
+See [Present your SSH key]({{%ref "present-ssh-key" %}}) for recommended methods
 to present your SSH key, depending on what type of machine you are using.
 {{</alert>}}
 


### PR DESCRIPTION
- Fixes #262
  - Specifically the alert link underline, which is set in [this Sass CSS file upstream in Hinode
](https://github.com/gethinode/hinode/blob/a3e720c2991cdfed44809cce18b55a8bfd6ea2e3/assets/scss/components/_alert.scss#L15)
- this PR overrides link underlines with the inherited colour
  - dotted underline that goes solid when hovering
  - thicker underline than default of theme
  - same colour as rest of alert text, goes lighter when hovering
  - tested in light and dark mode