### PR TITLE
Updating instructions for linking CEDA & JASMIN accounts

### DIFF
--- a/content/docs/getting-started/get-started-with-jasmin.md
+++ b/content/docs/getting-started/get-started-with-jasmin.md
@@ -40,7 +40,7 @@ Step  |  Details  |  Comments
 ---|---|---
 5  |  Apply for access to additional services on JASMIN<br>(optional) |  JASMIN has a range of additional services, access to which is managed via the Accounts Portal. Search and apply for any services you require in the portal. In most cases, users will "belong" to a particular scientific project which may already have a presence on JASMIN, often in the form of a [Group Workspace]({{% ref "short-term-project-storage" %}}). See here how to [Apply for access to a Group Workspace]({{% ref "apply-for-access-to-a-gws" %}}).
 6  |  [Get a CEDA account]({{% ref "ceda-archive" %}})<br>(optional) |  If you will need to access data in the {{<link "ceda_archive">}}CEDA Archive{{</link>}} for your work, it's accessible read-only throughout JASMIN,  Some datasets on the CEDA Archive require specific agreements, and to apply for access to these, you will need a CEDA account.  
-7  |  {{<link "https://help.ceda.ac.uk/article/5105-linking-your-jasmin-account">}}Link your JASMIN and CEDA accounts{{</link>}} (optional)  |  The final step is to link your CEDA account to your JASMIN account. This lets you access CEDA data on JASMIN, with the same dataset access permissions that your linked CEDA account has.
+7  |  {{<link "https://help.ceda.ac.uk/article/5105-linking-your-jasmin-account">}}Link your JASMIN and CEDA accounts{{</link>}} (optional)  |  The final step is to link your CEDA account to your JASMIN account in the CEDA accounts portal. This lets you access CEDA data on JASMIN, with the same dataset access permissions that your linked CEDA account has.
 {.table .table-striped}
 
 ## Further information

--- a/content/docs/getting-started/get-started-with-jasmin.md
+++ b/content/docs/getting-started/get-started-with-jasmin.md
@@ -40,7 +40,7 @@ Step  |  Details  |  Comments
 ---|---|---
 5  |  Apply for access to additional services on JASMIN<br>(optional) |  JASMIN has a range of additional services, access to which is managed via the Accounts Portal. Search and apply for any services you require in the portal. In most cases, users will "belong" to a particular scientific project which may already have a presence on JASMIN, often in the form of a [Group Workspace]({{% ref "short-term-project-storage" %}}). See here how to [Apply for access to a Group Workspace]({{% ref "apply-for-access-to-a-gws" %}}).
 6  |  [Get a CEDA account]({{% ref "ceda-archive" %}})<br>(optional) |  If you will need to access data in the {{<link "ceda_archive">}}CEDA Archive{{</link>}} for your work, it's accessible read-only throughout JASMIN,  Some datasets on the CEDA Archive require specific agreements, and to apply for access to these, you will need a CEDA account.  
-7  |  [Link your JASMIN and CEDA accounts]({{% ref "update-a-jasmin-account#link-ceda-account" %}}) (optional)  |  The final step is to link your CEDA account to your JASMIN account. This lets you access CEDA data on JASMIN, with the same dataset access permissions that your linked CEDA account has.
+7  |  {{<link "https://help.ceda.ac.uk/article/5105-linking-your-jasmin-account">}}Link your JASMIN and CEDA accounts{{</link>}} (optional)  |  The final step is to link your CEDA account to your JASMIN account. This lets you access CEDA data on JASMIN, with the same dataset access permissions that your linked CEDA account has.
 {.table .table-striped}
 
 ## Further information

--- a/content/docs/getting-started/update-a-jasmin-account.md
+++ b/content/docs/getting-started/update-a-jasmin-account.md
@@ -66,23 +66,4 @@ Re-enter the new password to confirm, then click "Change password"
 Linking your CEDA account to your JASMIN account allows you filesystem access
 to data on CEDA Archive. If you need to access data on the CEDA Archive and
 you do not have an account, you will need to apply for a
-[CEDA account]({{% ref "ceda-archive#register" %}}).
-
-**Step 1** : On the profile page, select "Link now" which is next to the
-field "Linked CEDA Account". This will take you to the CEDA accounts portal
-page where you need to login.
-
-{{<image src="img/docs/update-a-jasmin-account/ceda-account-login.png" caption="CEDA accounts portal login page">}}
-
-**Step 2** : You will be directed to the page below to authorise the CEDA
-accounts portal to link your JASMIN account.
-
-{{<image src="img/docs/update-a-jasmin-account/ceda-link-account.png" caption="CEDA accounts portal linking page">}}
-
-**Step 3** : Then you will be sent to the page below to authorise the JASMIN accounts portal to grant the CEDA accounts portal information about your JASMIN profile.
-
-{{<image src="img/docs/update-a-jasmin-account/jasmin-link-account.png" caption="JASMIN accounts portal linking page">}}
-
-**Step 4** : Finally, a box confirming you've linked your accounts is shown in the CEDA accounts portal. As shown below, a field stating "Linked to JASMIN account: `<JASMIN username>`" should show the name of the account you have linked.
-
-{{<image src="img/docs/update-a-jasmin-account/ceda-link-success.png" caption="CEDA accounts portal showing a successful link">}}
+[CEDA account]({{% ref "ceda-archive#register" %}}). Once you have a CEDA account, instructions for linking it with your JASMIN account can be found on {{<link "https://help.ceda.ac.uk/article/5105-linking-your-jasmin-account">}}the CEDA help site{{</link>}}.


### PR DESCRIPTION
- Changed link in 'Get Started with JASMIN' to go to CEDA help site docs
- Replaced instructions with link to CEDA help site docs in relevant 'Update a JASMIN account' section