### PR TITLE
Add mailing list details to "JASMIN status" page

### DIFF
--- a/content/docs/getting-started/jasmin-status.md
+++ b/content/docs/getting-started/jasmin-status.md
@@ -1,15 +1,13 @@
 ---
 aliases: /article/194-jasmin-live-status
-description: JASMIN status
+description: Sources of information about the status of JASMIN services
 title: JASMIN status
 weight: 70
 ---
 
-This article lists sources of information about the status of JASMIN services.
-
 ## CEDA Status page
 
-The {{< link "ceda_status" >}}CEDA Status page{{< /link >}} is updated regularly to announce or track current and upcoming incidents which may affect JASMIN and CEDA services. Please check for known incidents or announced shceduled maintenance before contacting the helpdesk.
+The {{< link "ceda_status" >}}CEDA Status page{{< /link >}} is updated regularly to announce or track current and upcoming incidents which may affect JASMIN and CEDA services. Please check for known incidents or announced scheduled maintenance before contacting the helpdesk.
 
 ## JASMIN dashboard
 
@@ -17,7 +15,7 @@ The {{<link "https://mon.jasmin.ac.uk" >}}JASMIN metrics dashboard{{</link>}} ha
 
 Please read the introductory information on that page.
 
-Currrently it provides:
+Currently it provides:
 - GWS Dashboard
   - view of all the volumes in a group workspace across different storage types, showing quota and usage
 - LOTUS Dashboard
@@ -29,6 +27,32 @@ Currrently it provides:
 
 This is still under active development and further dashboards may be added in due course.
 
-Please also keep an eye on:
-- `JASMIN-USERS` email list (all users should be on this list. If not, please ask)
-- {{< link ceda_news >}}CEDA News{{< /link >}} articles on the CEDA website
+## JASMIN mailing lists
+
+### JASMIN Users
+
+After you are granted access to JASMIN, you should be added to this Jiscmail mailing list. We will occasionally send updates about JASMIN services, including:
+
+- When specific machines or services will be temporarily unavailable
+- When new servers are available or old ones will be turned off
+- When there is an action that all JASMIN users need to take
+- When a holiday period is coming up and support will be reduced
+- When there is an upcoming webinar or other event relevant to JASMIN users
+
+If you are not on this list, please ask to be added [via the JASMIN Helpdesk](mailto:support@jasmin.ac.uk).
+
+### JASMIN GWS Managers
+
+If you manage a Group Workspace, you will also be added to this mailing list for important updates about Group Workspaces.
+
+### JASMIN Cloud Admins
+
+If you manage a cloud tenancy, you will also be added to this mailing list to for important updates about the JASMIN Cloud.
+
+### Unsubscribing
+
+We recommend that all users of JASMIN remain subscribed to the relevant lists to receive important service announcements. However, if you prefer not to, please click the unsubscribe link in the footer of these emails.
+
+## CEDA Website
+
+Please also keep an eye on {{< link ceda_news >}}CEDA News{{< /link >}} articles on the CEDA website, especially [those tagged as JASMIN related](https://www.ceda.ac.uk/tags/jasmin/) which include the most important updates to users.

--- a/content/docs/getting-started/jasmin-status.md
+++ b/content/docs/getting-started/jasmin-status.md
@@ -31,7 +31,8 @@ This is still under active development and further dashboards may be added in du
 
 ### JASMIN Users
 
-After you are granted access to JASMIN, you should be added to this Jiscmail mailing list. We will occasionally send updates about JASMIN services, including:
+After requesting access to [JASMIN login
+services]({{% ref "get-login-account" %}}) and being approved, you should be added to this Jiscmail mailing list. We will occasionally send updates about JASMIN services, including:
 
 - When specific machines or services will be temporarily unavailable
 - When new servers are available or old ones will be turned off


### PR DESCRIPTION
- Expand details about mailing lists, and how to follow JASMIN updates on the CEDA site
- Fixed a few typos
- Added a description to the page

Not to be merged until the mailing list footer is added!